### PR TITLE
Cleaner ReleaseType parsing from project properties

### DIFF
--- a/src/main/kotlin/me/modmuss50/mpp/ModPublishExtension.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/ModPublishExtension.kt
@@ -21,9 +21,9 @@ import kotlin.reflect.KClass
 
 abstract class ModPublishExtension(val project: Project) : PublishOptions {
     // Removes the need to import the release type, a little gross tho?
-    val BETA = PublishOptions.ReleaseType.BETA
-    val ALPHA = PublishOptions.ReleaseType.ALPHA
-    val STABLE = PublishOptions.ReleaseType.STABLE
+    val BETA = ReleaseType.BETA
+    val ALPHA = ReleaseType.ALPHA
+    val STABLE = ReleaseType.STABLE
 
     abstract val dryRun: Property<Boolean>
     val platforms: ExtensiblePolymorphicDomainObjectContainer<Platform> = project.objects.polymorphicDomainObjectContainer(Platform::class.java)

--- a/src/main/kotlin/me/modmuss50/mpp/PublishOptions.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/PublishOptions.kt
@@ -44,10 +44,4 @@ interface PublishOptions {
         additionalFiles.setFrom(other.additionalFiles)
         maxRetries.set(other.maxRetries)
     }
-
-    enum class ReleaseType {
-        STABLE,
-        BETA,
-        ALPHA,
-    }
 }

--- a/src/main/kotlin/me/modmuss50/mpp/ReleaseType.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/ReleaseType.kt
@@ -1,7 +1,21 @@
 package me.modmuss50.mpp
 
+import java.lang.IllegalArgumentException
+
 enum class ReleaseType {
     STABLE,
     BETA,
-    ALPHA,
+    ALPHA;
+
+    companion object {
+        @JvmStatic
+        fun of(value: String): ReleaseType {
+            val upper = value.uppercase()
+            try {
+                return ReleaseType.valueOf(upper)
+            } catch (e: IllegalArgumentException) {
+                throw IllegalArgumentException("Invalid release type: ${upper}. Must be one of: STABLE, BETA, ALPHA")
+            }
+        }
+    }
 }

--- a/src/main/kotlin/me/modmuss50/mpp/ReleaseType.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/ReleaseType.kt
@@ -5,7 +5,7 @@ import java.lang.IllegalArgumentException
 enum class ReleaseType {
     STABLE,
     BETA,
-    ALPHA;
+    ALPHA, ;
 
     companion object {
         @JvmStatic
@@ -14,7 +14,7 @@ enum class ReleaseType {
             try {
                 return ReleaseType.valueOf(upper)
             } catch (e: IllegalArgumentException) {
-                throw IllegalArgumentException("Invalid release type: ${upper}. Must be one of: STABLE, BETA, ALPHA")
+                throw IllegalArgumentException("Invalid release type: $upper. Must be one of: STABLE, BETA, ALPHA")
             }
         }
     }

--- a/src/main/kotlin/me/modmuss50/mpp/ReleaseType.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/ReleaseType.kt
@@ -1,0 +1,7 @@
+package me.modmuss50.mpp
+
+enum class ReleaseType {
+    STABLE,
+    BETA,
+    ALPHA,
+}

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeApi.kt
@@ -7,7 +7,6 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import me.modmuss50.mpp.HttpUtils
 import me.modmuss50.mpp.PlatformDependency
-import me.modmuss50.mpp.PublishOptions
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
@@ -49,11 +48,11 @@ class CurseforgeApi(private val accessToken: String, private val baseUrl: String
         ;
 
         companion object {
-            fun valueOf(type: PublishOptions.ReleaseType): ReleaseType {
+            fun valueOf(type: me.modmuss50.mpp.ReleaseType): ReleaseType {
                 return when (type) {
-                    PublishOptions.ReleaseType.STABLE -> RELEASE
-                    PublishOptions.ReleaseType.BETA -> BETA
-                    PublishOptions.ReleaseType.ALPHA -> ALPHA
+                    me.modmuss50.mpp.ReleaseType.STABLE -> RELEASE
+                    me.modmuss50.mpp.ReleaseType.BETA -> BETA
+                    me.modmuss50.mpp.ReleaseType.ALPHA -> ALPHA
                 }
             }
         }

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/github/Github.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/github/Github.kt
@@ -1,6 +1,9 @@
 package me.modmuss50.mpp.platforms.github
 
-import me.modmuss50.mpp.*
+import me.modmuss50.mpp.Platform
+import me.modmuss50.mpp.PlatformOptions
+import me.modmuss50.mpp.PlatformOptionsInternal
+import me.modmuss50.mpp.ReleaseType
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/github/Github.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/github/Github.kt
@@ -1,9 +1,6 @@
 package me.modmuss50.mpp.platforms.github
 
-import me.modmuss50.mpp.Platform
-import me.modmuss50.mpp.PlatformOptions
-import me.modmuss50.mpp.PlatformOptionsInternal
-import me.modmuss50.mpp.PublishOptions
+import me.modmuss50.mpp.*
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
@@ -61,7 +58,7 @@ abstract class Github @Inject constructor(name: String) : Platform(name), Github
                 val release = with(GHReleaseBuilder(repo, version.get())) {
                     name(displayName.get())
                     body(changelog.get())
-                    prerelease(type.get() != PublishOptions.ReleaseType.STABLE)
+                    prerelease(type.get() != ReleaseType.STABLE)
                     commitish(commitish.get())
                 }.create()
 

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/modrinth/ModrinthApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/modrinth/ModrinthApi.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import me.modmuss50.mpp.HttpUtils
 import me.modmuss50.mpp.PlatformDependency
-import me.modmuss50.mpp.PublishOptions
+import me.modmuss50.mpp.ReleaseType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
@@ -32,11 +32,11 @@ class ModrinthApi(private val accessToken: String, private val baseUrl: String) 
         ;
 
         companion object {
-            fun valueOf(type: PublishOptions.ReleaseType): VersionType {
+            fun valueOf(type: ReleaseType): VersionType {
                 return when (type) {
-                    PublishOptions.ReleaseType.STABLE -> RELEASE
-                    PublishOptions.ReleaseType.BETA -> BETA
-                    PublishOptions.ReleaseType.ALPHA -> ALPHA
+                    ReleaseType.STABLE -> RELEASE
+                    ReleaseType.BETA -> BETA
+                    ReleaseType.ALPHA -> ALPHA
                 }
             }
         }


### PR DESCRIPTION
## Motivation
This makes `ReleaseType` class accessible in build configuration, so setup like this is possible:
`gradle.properties`
```properties
# ... 
release_type=stable
```

`build.gradle`
```gradle
import me.modmuss50.mpp.ReleaseType
// ...
publishMods {
    type = ReleaseType.of(project.release_type)
    // ...
}

```
## Current behaviour
Currently this can be replicated this way:
`build.gradle`
```gradle
import me.modmuss50.mpp.PublishOptions
// ...
publishMods {
    type = PublishOptions.ReleaseType.valueOf(project.release_type.toUpperCase())
    // ...
}
```
This approach includes more boilerplate and has a less descriptive error message.