### PR TITLE
Potential Fix for #12

### DIFF
--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
@@ -129,7 +129,7 @@ abstract class Curseforge @Inject constructor(name: String) : Platform(name), Cu
                 }
 
                 for (additionalFile in additionalFiles.files) {
-                    val additionalMetadata = metadata.copy(parentFileID = response.id, gameVersions = emptyList())
+                    val additionalMetadata = metadata.copy(parentFileID = response.id, gameVersions = null)
 
                     val additionalResponse = HttpUtils.retry(maxRetries.get(), "Failed to upload additional file") {
                         api.uploadFile(projectId.get(), additionalFile.toPath(), additionalMetadata)

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeApi.kt
@@ -16,7 +16,8 @@ import kotlin.io.path.name
 
 // https://support.curseforge.com/en/support/solutions/articles/9000197321-curseforge-upload-api
 class CurseforgeApi(private val accessToken: String, private val baseUrl: String) {
-    val json = Json
+    // dont serialize nulls
+    val json = Json { explicitNulls = false }
 
     private val httpUtils = HttpUtils(exceptionFactory = CurseforgeHttpExceptionFactory())
 
@@ -64,7 +65,7 @@ class CurseforgeApi(private val accessToken: String, private val baseUrl: String
         val changelogType: String? = null, // Optional: defaults to text
         val displayName: String? = null, // Optional: A friendly display name used on the site if provided.
         val parentFileID: Int? = null, // Optional: The parent file of this file.
-        val gameVersions: List<Int>, // A list of supported game versions, see the Game Versions API for details. Not supported if parentFileID is provided.
+        val gameVersions: List<Int>?, // A list of supported game versions, see the Game Versions API for details. Not supported if parentFileID is provided.
         val releaseType: ReleaseType,
         val relations: UploadFileRelations? = null,
     )

--- a/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeTest.kt
@@ -45,8 +45,8 @@ class CurseforgeTest : IntegrationTest {
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishCurseforge")!!.outcome)
         assertEquals("Hello!", metadata.changelog)
         assertEquals("Test Upload", metadata.displayName)
-        assertContains(metadata.gameVersions, 9990) // 1.20.1
-        assertContains(metadata.gameVersions, 7499) // Fabric
+        assertContains(metadata.gameVersions!!, 9990) // 1.20.1
+        assertContains(metadata.gameVersions!!, 7499) // Fabric
         assertEquals("fabric-api", metadata.relations!!.projects[0].slug)
     }
 


### PR DESCRIPTION
Do not provide `gameVersions` if `parentFileID` for CurseForge uploads.

Fix CurseForge json encoder serializing nulls, CurseForge treats nulls as "provided" values, causing this whole issue (#11 & #12) with `gameVersions`.

---

As you can see in the below images with these changes applied, I was able to publish the plugin to local maven, include it in my mod and use it to publish to CurseForge with no problems.

<details>

### Image showing gradle finished with no errors

![image](https://github.com/modmuss50/mod-publish-plugin/assets/29412632/316d800c-855d-48b2-9cb6-6a39cca07674)

### Image showing file uploaded with `additionalFiles`

![image](https://github.com/modmuss50/mod-publish-plugin/assets/29412632/d84009fd-26ec-492d-b3ce-ad7147078fce)

</details>