### PR TITLE
Support optional github tag name for release creation

### DIFF
--- a/docs/pages/platforms/github.mdx
+++ b/docs/pages/platforms/github.mdx
@@ -36,6 +36,7 @@ publishMods {
         accessToken = providers.environmentVariable("GITHUB_TOKEN")
         repository = "Example/MyMod"
         commitish = "main"
+        tagName = "release/1.0.0"
     }
 }
 ```

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/github/Github.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/github/Github.kt
@@ -31,6 +31,10 @@ interface GithubOptions : PlatformOptions, PlatformOptionsInternal<GithubOptions
 
     @get:Input
     @get:Optional
+    val tagName: Property<String>
+
+    @get:Input
+    @get:Optional
     val apiEndpoint: Property<String>
 
     override fun setInternalDefaults() {
@@ -41,6 +45,7 @@ interface GithubOptions : PlatformOptions, PlatformOptionsInternal<GithubOptions
         repository.set(other.repository)
         commitish.set(other.commitish)
         apiEndpoint.set(other.apiEndpoint)
+        tagName.set(other.tagName)
     }
 
     fun from(other: Provider<GithubOptions>) {
@@ -69,7 +74,7 @@ abstract class Github @Inject constructor(name: String) : Platform(name), Github
                 val mainFile = file.get().asFile
 
                 val repo = connect().getRepository(repository.get())
-                val release = with(GHReleaseBuilder(repo, version.get())) {
+                val release = with(GHReleaseBuilder(repo, tagName.getOrElse(version.get()))) {
                     name(displayName.get())
                     body(changelog.get())
                     prerelease(type.get() != ReleaseType.STABLE)

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/github/Github.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/github/Github.kt
@@ -30,7 +30,6 @@ interface GithubOptions : PlatformOptions, PlatformOptionsInternal<GithubOptions
     val commitish: Property<String>
 
     @get:Input
-    @get:Optional
     val tagName: Property<String>
 
     @get:Input
@@ -38,6 +37,7 @@ interface GithubOptions : PlatformOptions, PlatformOptionsInternal<GithubOptions
     val apiEndpoint: Property<String>
 
     override fun setInternalDefaults() {
+        tagName.convention(version)
     }
 
     fun from(other: GithubOptions) {
@@ -74,7 +74,7 @@ abstract class Github @Inject constructor(name: String) : Platform(name), Github
                 val mainFile = file.get().asFile
 
                 val repo = connect().getRepository(repository.get())
-                val release = with(GHReleaseBuilder(repo, tagName.getOrElse(version.get()))) {
+                val release = with(GHReleaseBuilder(repo, tagName.get())) {
                     name(displayName.get())
                     body(changelog.get())
                     prerelease(type.get() != ReleaseType.STABLE)

--- a/src/test/kotlin/me/modmuss50/mpp/test/github/GithubTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/github/GithubTest.kt
@@ -24,6 +24,7 @@ class GithubTest : IntegrationTest {
                             repository = "test/example"
                             commitish = "main"
                             apiEndpoint = "${server.endpoint}"
+                            tagName = "release/1.0.0"
                         }
                     }
                 """.trimIndent(),


### PR DESCRIPTION
It's not always intended behaviour for users to want the tag name of the release to match the version number. For example, in my build scripts, I typically use `release/{mc_version}/{mod_version}`. I've added an optional field to allow for a custom tag name to be supplied. 