### PR TITLE
Remove restriction disallowing version ranges containing one version

### DIFF
--- a/src/main/kotlin/me/modmuss50/mpp/MinecraftApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/MinecraftApi.kt
@@ -38,7 +38,6 @@ class MinecraftApi(private val baseUrl: String = "https://piston-meta.mojang.com
         if (startIndex == -1) throw IllegalArgumentException("Invalid start version $startId")
         if (endIndex == -1) throw IllegalArgumentException("Invalid end version $endId")
         if (startIndex > endIndex) throw IllegalArgumentException("Start version $startId must be before end version $endId")
-        if (startIndex == endIndex) throw IllegalArgumentException("Start version $startId cannot be the same as end version $endId")
 
         return versions.subList(startIndex, endIndex + 1)
     }

--- a/src/test/kotlin/me/modmuss50/mpp/test/misc/MinecraftApiTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/misc/MinecraftApiTest.kt
@@ -62,4 +62,16 @@ class MinecraftApiTest {
 
         server.close()
     }
+
+    @Test
+    fun getSingleVersionFromRange() {
+        val server = MockWebServer(MockMinecraftApi())
+        val api = MinecraftApi(server.endpoint)
+
+        val versions = api.getVersionsInRange("1.19.4", "1.19.4", true)
+        assert(versions.size == 1)
+        assertContains(versions, "1.19.4")
+
+        server.close()
+    }
 }


### PR DESCRIPTION
Resolves #49.

Figured I'd do this real quick since it's just removing the check.