### PR TITLE
Close #58 Add configuration for CurseForge changelog type

### DIFF
--- a/docs/pages/platforms/curseforge.mdx
+++ b/docs/pages/platforms/curseforge.mdx
@@ -70,6 +70,10 @@ publishMods {
         optional("project-slug")
         incompatible("project-slug")
         embeds("project-slug")
+
+        // Set a changelog using text, markdown, or html (defaults to markdown)
+        changelog = "# Markdown changelog content"
+        changelogType = MARKDOWN
     }
 }
 ```

--- a/docs/pages/platforms/curseforge.mdx
+++ b/docs/pages/platforms/curseforge.mdx
@@ -73,7 +73,7 @@ publishMods {
 
         // Set a changelog using text, markdown, or html (defaults to markdown)
         changelog = "# Markdown changelog content"
-        changelogType = MARKDOWN
+        changelogType = "markdown"
     }
 }
 ```

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
@@ -53,6 +53,11 @@ interface CurseforgeOptions : PlatformOptions, PlatformOptionsInternal<Curseforg
     @get:Input
     val apiEndpoint: Property<String>
 
+    // Set the type of changelog for CurseForge. If unset, defaults to MARKDOWN
+    @get:Input
+    @get:Optional
+    val changelogType: Property<CurseforgeApi.ChangelogType>
+
     fun from(other: CurseforgeOptions) {
         super.from(other)
         fromDependencies(other)
@@ -63,6 +68,7 @@ interface CurseforgeOptions : PlatformOptions, PlatformOptionsInternal<Curseforg
         serverRequired.set(other.serverRequired)
         javaVersions.set(other.javaVersions)
         apiEndpoint.set(other.apiEndpoint)
+        changelogType.set(other.changelogType)
     }
 
     fun from(other: Provider<CurseforgeOptions>) {
@@ -219,7 +225,7 @@ abstract class Curseforge @Inject constructor(name: String) : Platform(name), Cu
 
                 val metadata = CurseforgeApi.UploadFileMetadata(
                     changelog = changelog.get(),
-                    changelogType = "markdown",
+                    changelogType = changelogType.getOrElse(CurseforgeApi.ChangelogType.MARKDOWN),
                     displayName = displayName.get(),
                     gameVersions = gameVersions,
                     releaseType = CurseforgeApi.ReleaseType.valueOf(type.get()),

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
@@ -53,9 +53,8 @@ interface CurseforgeOptions : PlatformOptions, PlatformOptionsInternal<Curseforg
     @get:Input
     val apiEndpoint: Property<String>
 
-    // Set the type of changelog for CurseForge. If unset, defaults to MARKDOWN
     @get:Input
-    val changelogType: Property<CurseforgeApi.ChangelogType>
+    val changelogType: Property<String>
 
     fun from(other: CurseforgeOptions) {
         super.from(other)
@@ -95,7 +94,7 @@ interface CurseforgeOptions : PlatformOptions, PlatformOptionsInternal<Curseforg
 
     override fun setInternalDefaults() {
         apiEndpoint.convention("https://minecraft.curseforge.com")
-        changelogType.convention(CurseforgeApi.ChangelogType.MARKDOWN)
+        changelogType.convention("markdown")
     }
 
     override val platformDependencyKClass: KClass<CurseforgeDependency>
@@ -225,7 +224,7 @@ abstract class Curseforge @Inject constructor(name: String) : Platform(name), Cu
 
                 val metadata = CurseforgeApi.UploadFileMetadata(
                     changelog = changelog.get(),
-                    changelogType = changelogType.get(),
+                    changelogType = CurseforgeApi.ChangelogType.of(changelogType.get()),
                     displayName = displayName.get(),
                     gameVersions = gameVersions,
                     releaseType = CurseforgeApi.ReleaseType.valueOf(type.get()),

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
@@ -55,7 +55,6 @@ interface CurseforgeOptions : PlatformOptions, PlatformOptionsInternal<Curseforg
 
     // Set the type of changelog for CurseForge. If unset, defaults to MARKDOWN
     @get:Input
-    @get:Optional
     val changelogType: Property<CurseforgeApi.ChangelogType>
 
     fun from(other: CurseforgeOptions) {
@@ -96,6 +95,7 @@ interface CurseforgeOptions : PlatformOptions, PlatformOptionsInternal<Curseforg
 
     override fun setInternalDefaults() {
         apiEndpoint.convention("https://minecraft.curseforge.com")
+        changelogType.convention(CurseforgeApi.ChangelogType.MARKDOWN)
     }
 
     override val platformDependencyKClass: KClass<CurseforgeDependency>
@@ -225,7 +225,7 @@ abstract class Curseforge @Inject constructor(name: String) : Platform(name), Cu
 
                 val metadata = CurseforgeApi.UploadFileMetadata(
                     changelog = changelog.get(),
-                    changelogType = changelogType.getOrElse(CurseforgeApi.ChangelogType.MARKDOWN),
+                    changelogType = changelogType.get(),
                     displayName = displayName.get(),
                     gameVersions = gameVersions,
                     releaseType = CurseforgeApi.ReleaseType.valueOf(type.get()),

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeApi.kt
@@ -72,6 +72,18 @@ class CurseforgeApi(private val accessToken: String, private val baseUrl: String
         @SerialName("markdown")
         MARKDOWN,
         ;
+
+        companion object {
+            @JvmStatic
+            fun of(value: String): ChangelogType {
+                val upper = value.uppercase()
+                try {
+                    return ChangelogType.valueOf(upper)
+                } catch (e: java.lang.IllegalArgumentException) {
+                    throw java.lang.IllegalArgumentException("Invalid changelog type: $upper. Must be one of: TEXT, HTML, MARKDOWN")
+                }
+            }
+        }
     }
 
     @Serializable

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeApi.kt
@@ -62,9 +62,22 @@ class CurseforgeApi(private val accessToken: String, private val baseUrl: String
     }
 
     @Serializable
+    enum class ChangelogType {
+        @SerialName("text")
+        TEXT,
+
+        @SerialName("html")
+        HTML,
+
+        @SerialName("markdown")
+        MARKDOWN,
+        ;
+    }
+
+    @Serializable
     data class UploadFileMetadata(
         val changelog: String, // Can be HTML or markdown if changelogType is set.
-        val changelogType: String? = null, // Optional: defaults to text
+        val changelogType: ChangelogType? = null, // Optional: defaults to text
         val displayName: String? = null, // Optional: A friendly display name used on the site if provided.
         val parentFileID: Int? = null, // Optional: The parent file of this file.
         val gameVersions: List<Int>?, // A list of supported game versions, see the Game Versions API for details. Not supported if parentFileID is provided.


### PR DESCRIPTION
This will let modders specify the type of changelog sent to CurseForge, instead of having it hard-coded as markdown.

Please let me know if there is a good way to test this, or if it's good enough as-is.
I'm not familiar with this codebase, but happy to make changes so that this is up to a better standard.