### PR TITLE
docs: Fix errors/outdated data on the documentation

### DIFF
--- a/docs/pages/platforms/discord.mdx
+++ b/docs/pages/platforms/discord.mdx
@@ -74,7 +74,7 @@ The look can be set to `CLASSIC` or `MODERN`
       // ...
       style {
         // ...
-        look = MODERN
+        look = "MODERN"
       }
     }
   }
@@ -93,9 +93,9 @@ The look can be set to `CLASSIC` or `MODERN`
       // ...
       style {
         // ...
-        look = MODERN
-        thumbnailUrl = https://example.com
-        color = "github"
+        look = "MODERN"
+        thumbnailUrl = "https://example.com"
+        color = "#f6f0fc"
       }
     }
   }
@@ -118,7 +118,7 @@ You can also set your links to be posted as `EMBED` or `BUTTON`
       // ...
       style {
         // ...
-        link = BUTTON
+        link = "BUTTON"
       }
     }
   }


### PR DESCRIPTION
The documentation was not fully updated to reflect the final state of #61 

This fixes a small mistake done by me originally and updates the docs to better reflect the merged changes

It also changes the example usage of `style.color` to use a hex color instead of a platform