### PR TITLE
Allow providing a version slug instead of version id for modrinth publishing

### DIFF
--- a/docs/pages/platforms/modrinth.mdx
+++ b/docs/pages/platforms/modrinth.mdx
@@ -66,7 +66,7 @@ publishMods {
             id = "12345678"
             slug = "project-slug"
 
-            // You can optionally specify a version id for the dependency
+            // You can optionally specify a version id or name for the dependency
             version = "IIJJKKLL"
         }
         optional {

--- a/src/main/kotlin/me/modmuss50/mpp/HttpUtils.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/HttpUtils.kt
@@ -26,14 +26,6 @@ class HttpUtils(val exceptionFactory: HttpExceptionFactory = DefaultHttpExceptio
         .build()
     val json = Json { ignoreUnknownKeys = true }
 
-    inline fun <reified T> get(url: String): T {
-        return request(
-            Request.Builder()
-                .url(url),
-            emptyMap()
-        )
-    }
-
     inline fun <reified T> get(url: String, headers: Map<String, String>): T {
         return request(
             Request.Builder()

--- a/src/main/kotlin/me/modmuss50/mpp/HttpUtils.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/HttpUtils.kt
@@ -26,6 +26,14 @@ class HttpUtils(val exceptionFactory: HttpExceptionFactory = DefaultHttpExceptio
         .build()
     val json = Json { ignoreUnknownKeys = true }
 
+    inline fun <reified T> get(url: String): T {
+        return request(
+            Request.Builder()
+                .url(url),
+            emptyMap()
+        )
+    }
+
     inline fun <reified T> get(url: String, headers: Map<String, String>): T {
         return request(
             Request.Builder()

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/modrinth/Modrinth.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/modrinth/Modrinth.kt
@@ -304,6 +304,10 @@ abstract class Modrinth @Inject constructor(name: String) : Platform(name), Modr
                             versionId = version.id
                         }
                     }
+                    
+                    if (versionId == null) {
+                        throw IllegalStateException("Modrinth dependency has a configured versionSlug but no matching version could be found!")
+                    }
                 }
 
                 // Ensure we have an id

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/modrinth/ModrinthApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/modrinth/ModrinthApi.kt
@@ -13,6 +13,7 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import sun.jvm.hotspot.code.NMethod
 import java.nio.file.Path
 import java.time.Duration
 import kotlin.io.path.name
@@ -110,6 +111,15 @@ class ModrinthApi(private val accessToken: String, private val baseUrl: String) 
             }
         }
     }
+    
+    // There's more but we don't need it
+    @Serializable
+    data class ListVersionsResponse(
+        val name: String,
+        @SerialName("version_number")
+        val versionNumber: String,
+        val id: String
+    )
 
     // There is a lot more to this response, however we dont need it.
     @Serializable
@@ -143,6 +153,10 @@ class ModrinthApi(private val accessToken: String, private val baseUrl: String) 
             "Authorization" to accessToken,
             "Content-Type" to "application/json",
         )
+    
+    fun listVersions(projectSlug: String): Array<ListVersionsResponse> {
+        return httpUtils.get("$baseUrl/project/$projectSlug/version")
+    }
 
     fun createVersion(metadata: CreateVersion, files: Map<String, Path>): CreateVersionResponse {
         val mediaType = "application/java-archive".toMediaTypeOrNull()

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/modrinth/ModrinthApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/modrinth/ModrinthApi.kt
@@ -110,13 +110,13 @@ class ModrinthApi(private val accessToken: String, private val baseUrl: String) 
             }
         }
     }
-    
+
     // There's more but we don't need it
     @Serializable
     data class ListVersionsResponse(
         @SerialName("version_number")
         val versionNumber: String,
-        val id: String
+        val id: String,
     )
 
     // There is a lot more to this response, however we dont need it.
@@ -151,7 +151,7 @@ class ModrinthApi(private val accessToken: String, private val baseUrl: String) 
             "Authorization" to accessToken,
             "Content-Type" to "application/json",
         )
-    
+
     fun listVersions(projectSlug: String): Array<ListVersionsResponse> {
         return httpUtils.get("$baseUrl/project/$projectSlug/version", headers)
     }

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/modrinth/ModrinthApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/modrinth/ModrinthApi.kt
@@ -13,7 +13,6 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import sun.jvm.hotspot.code.NMethod
 import java.nio.file.Path
 import java.time.Duration
 import kotlin.io.path.name
@@ -115,7 +114,6 @@ class ModrinthApi(private val accessToken: String, private val baseUrl: String) 
     // There's more but we don't need it
     @Serializable
     data class ListVersionsResponse(
-        val name: String,
         @SerialName("version_number")
         val versionNumber: String,
         val id: String
@@ -155,7 +153,7 @@ class ModrinthApi(private val accessToken: String, private val baseUrl: String) 
         )
     
     fun listVersions(projectSlug: String): Array<ListVersionsResponse> {
-        return httpUtils.get("$baseUrl/project/$projectSlug/version")
+        return httpUtils.get("$baseUrl/project/$projectSlug/version", headers)
     }
 
     fun createVersion(metadata: CreateVersion, files: Map<String, Path>): CreateVersionResponse {

--- a/src/test/kotlin/me/modmuss50/mpp/test/modrinth/MockModrinthApi.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/modrinth/MockModrinthApi.kt
@@ -36,21 +36,21 @@ class MockModrinthApi : MockWebServer.MockApi {
             }
         }
     }
-    
+
     private fun listVersions(context: Context) {
         context.result(
             json.encodeToString(
                 arrayOf(
                     ModrinthApi.ListVersionsResponse(
                         "0.92.2+1.20.1",
-                        "P7uGFii0"
+                        "P7uGFii0",
                     ),
                     ModrinthApi.ListVersionsResponse(
                         "0.92.1+1.20.1",
-                        "ba99D9Qf"
-                    )
-                )
-            )
+                        "ba99D9Qf",
+                    ),
+                ),
+            ),
         )
     }
 

--- a/src/test/kotlin/me/modmuss50/mpp/test/modrinth/MockModrinthApi.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/modrinth/MockModrinthApi.kt
@@ -21,6 +21,9 @@ class MockModrinthApi : MockWebServer.MockApi {
 
     override fun routes(): EndpointGroup {
         return EndpointGroup {
+            path("/project/{slug}/version") {
+                get(this::listVersions)
+            }
             path("/version") {
                 before(this::authHandler)
                 post(this::createVersion)
@@ -32,6 +35,23 @@ class MockModrinthApi : MockWebServer.MockApi {
                 get(this::checkProject)
             }
         }
+    }
+    
+    private fun listVersions(context: Context) {
+        context.result(
+            json.encodeToString(
+                arrayOf(
+                    ModrinthApi.ListVersionsResponse(
+                        "0.92.2+1.20.1",
+                        "P7uGFii0"
+                    ),
+                    ModrinthApi.ListVersionsResponse(
+                        "0.92.1+1.20.1",
+                        "ba99D9Qf"
+                    )
+                )
+            )
+        )
     }
 
     private fun authHandler(context: Context) {


### PR DESCRIPTION
Adds support for providing a version slug when uploading to modrinth and depending on another mod
