### PR TITLE
feat: Gitea/Forgejo Publishing Options

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -3,8 +3,8 @@
 A modern Gradle plugin to publish Minecraft mods to a range of destinations. Start with the [Getting Started](/getting_started) page.
 
 ### Features
-- Supports CurseForge, Modrinth, Github and Discord
-- Typesafe DSL to easily publish to multiple locations with minimal repetition 
+- Supports CurseForge, Modrinth, Github, Gitea, Forgejo and Discord
+- Typesafe DSL to easily publish to multiple locations with minimal repetition
 - Retry on failure
 - Dry run mode to try and increase confidence in your buildscript before releases
 - Built with modern Gradle features

--- a/docs/pages/platforms/forgejo.mdx
+++ b/docs/pages/platforms/forgejo.mdx
@@ -1,0 +1,93 @@
+## Basic example
+See the following minimal example showing how to publish the `remapJar` task to Forgejo:
+```groovy
+publishMods {
+    file = remapJar.archiveFile
+    changelog = "Changelog"
+    type = STABLE
+    modLoaders.add("fabric")
+
+    forgejo {
+        accessToken = providers.environmentVariable("FORGEJO_TOKEN")
+        hostUrl(new URI("https://codeberg.org")) // This is the link for your Forgejo host.
+        repository = "Example/MyMod"
+        commitish = "main" // This is the branch the release tag will be created from
+    }
+}
+
+```
+## Multiple releases
+You can create multiple Forgejo destinations by specifying a name like so:
+```groovy
+publishMods {
+    forgejo("forgejoProjectA") {
+        // Configure forgejo settings for project A here
+    }
+
+    forgejo("forgejoProjectB") {
+        // Configure forgejo settings for project B here
+    }
+}
+```
+This will create 2 separate Forgejo releases.
+
+## Parent releases
+If you wish to upload files to a Forgejo release created by another task either in the same project or another subproject, you can use the `parent` option.
+This is useful where you have multiple subprojects that you want to publish to a single release, the following example shows how a root project can create the release and subprojects can upload files to it:
+
+#### Root project
+```groovy
+publishMods {
+    forgejo {
+        accessToken = providers.environmentVariable("FORGEJO_TOKEN")
+        repository = "Example/MyMod"
+        commitish = "main"
+        tagName = "release/1.0.0"
+
+        // Allow the release to be initially created without any files.
+        allowEmptyFiles = true
+    }
+}
+```
+
+#### Subproject
+When using the `parent` option, only the `accessToken` and files are required, the other options are forcefully inherited from the parent task.
+```groovy
+publishMods {
+    forgejo {
+        accessToken = providers.environmentVariable("FORGEJO_TOKEN")
+
+        // Specify the root project's forgejo task to upload files to
+        parent project(":").tasks.named("forgejo")
+    }
+}
+```
+
+## All options
+See the following example showing all the Forgejo specific options:
+```groovy
+publishMods {
+    forgejo {
+        accessToken = providers.environmentVariable("FORGEJO_TOKEN")
+        hostUrl(new URI("https://forgejo.example.com"))
+        repository = "Example/MyMod"
+        commitish = "main"
+        tagName = "release/1.0.0"
+
+        // Optionally set the announcement title used by the discord publisher
+        announcementTitle = "Download from Forgejo"
+		// Optionally set the display name for your host, which is used by the discord publisher if no custom title is set
+		hostDisplayName = "Example"
+        // Optionally set the brand color used by your host
+        hostBrandColor = 0xff5500
+
+        // Upload the files to a previously created release, by providing another forgejo publish task
+        // This is useful in multi-project builds where you want to publish multiple subprojects to a single release
+        parent tasks.named("publishForgejo")
+
+        // Optionally allow the release to be created without any attached files.
+        // This is useful when you have subprojects using the parent option that you want to publish a single release.
+        allowEmptyFiles = true
+    }
+}
+```

--- a/docs/pages/platforms/gitea.mdx
+++ b/docs/pages/platforms/gitea.mdx
@@ -1,0 +1,93 @@
+## Basic example
+See the following minimal example showing how to publish the `remapJar` task to Gitea:
+```groovy
+publishMods {
+    file = remapJar.archiveFile
+    changelog = "Changelog"
+    type = STABLE
+    modLoaders.add("fabric")
+
+    gitea {
+        accessToken = providers.environmentVariable("GITEA_TOKEN")
+        hostUrl(new URI("https://gitea.example.com")) // This is the link for your Gitea host.
+        repository = "Example/MyMod"
+        commitish = "main" // This is the branch the release tag will be created from
+    }
+}
+
+```
+## Multiple releases
+You can create multiple Gitea destinations by specifying a name like so:
+```groovy
+publishMods {
+    gitea("giteaProjectA") {
+        // Configure gitea settings for project A here
+    }
+
+    gitea("giteaProjectB") {
+        // Configure gitea settings for project B here
+    }
+}
+```
+This will create 2 separate Gitea releases.
+
+## Parent releases
+If you wish to upload files to a Gitea release created by another task either in the same project or another subproject, you can use the `parent` option.
+This is useful where you have multiple subprojects that you want to publish to a single release, the following example shows how a root project can create the release and subprojects can upload files to it:
+
+#### Root project
+```groovy
+publishMods {
+    gitea {
+        accessToken = providers.environmentVariable("GITEA_TOKEN")
+        repository = "Example/MyMod"
+        commitish = "main"
+        tagName = "release/1.0.0"
+
+        // Allow the release to be initially created without any files.
+        allowEmptyFiles = true
+    }
+}
+```
+
+#### Subproject
+When using the `parent` option, only the `accessToken` and files are required, the other options are forcefully inherited from the parent task.
+```groovy
+publishMods {
+    gitea {
+        accessToken = providers.environmentVariable("GITEA_TOKEN")
+
+        // Specify the root project's gitea task to upload files to
+        parent project(":").tasks.named("gitea")
+    }
+}
+```
+
+## All options
+See the following example showing all the Gitea specific options:
+```groovy
+publishMods {
+    gitea {
+        accessToken = providers.environmentVariable("GITEA_TOKEN")
+        hostUrl(new URI("https://gitea.example.com"))
+        repository = "Example/MyMod"
+        commitish = "main"
+        tagName = "release/1.0.0"
+
+        // Optionally set the announcement title used by the discord publisher
+        announcementTitle = "Download from Gitea"
+		// Optionally set the display name for your host, which is used by the discord publisher if no custom title is set
+		hostDisplayName = "Example"
+        // Optionally set the brand color used by your host
+        hostBrandColor = 0x1d8f4a
+
+        // Upload the files to a previously created release, by providing another gitea publish task
+        // This is useful in multi-project builds where you want to publish multiple subprojects to a single release
+        parent tasks.named("publishGitea")
+
+        // Optionally allow the release to be created without any attached files.
+        // This is useful when you have subprojects using the parent option that you want to publish a single release.
+        allowEmptyFiles = true
+    }
+}
+```

--- a/src/main/kotlin/me/modmuss50/mpp/ModPublishExtension.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/ModPublishExtension.kt
@@ -203,7 +203,6 @@ abstract class ModPublishExtension(val project: Project) : PublishOptions {
         }
     }
 
-
     // Forgejo
 
     fun forgejo(@DelegatesTo(value = Gitea::class) closure: Closure<*>): NamedDomainObjectProvider<Gitea> {

--- a/src/main/kotlin/me/modmuss50/mpp/ModPublishExtension.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/ModPublishExtension.kt
@@ -5,6 +5,9 @@ import groovy.lang.DelegatesTo
 import me.modmuss50.mpp.platforms.curseforge.Curseforge
 import me.modmuss50.mpp.platforms.curseforge.CurseforgeOptions
 import me.modmuss50.mpp.platforms.discord.DiscordWebhookTask
+import me.modmuss50.mpp.platforms.gitea.Gitea
+import me.modmuss50.mpp.platforms.gitea.GiteaOptions
+import me.modmuss50.mpp.platforms.gitea.GiteaOptions.HostType
 import me.modmuss50.mpp.platforms.github.Github
 import me.modmuss50.mpp.platforms.github.GithubOptions
 import me.modmuss50.mpp.platforms.modrinth.Modrinth
@@ -157,6 +160,83 @@ abstract class ModPublishExtension(val project: Project) : PublishOptions {
 
     fun githubOptions(action: Action<GithubOptions>): Provider<GithubOptions> {
         return configureOptions(GithubOptions::class) {
+            it.from(this)
+            action.execute(it)
+        }
+    }
+
+    // Gitea
+
+    fun gitea(@DelegatesTo(value = Gitea::class) closure: Closure<*>): NamedDomainObjectProvider<Gitea> {
+        return gitea {
+            project.configure(it, closure)
+        }
+    }
+
+    fun gitea(action: Action<Gitea>): NamedDomainObjectProvider<Gitea> {
+        return gitea("gitea", action)
+    }
+
+    fun gitea(name: String, @DelegatesTo(value = Gitea::class) closure: Closure<*>): NamedDomainObjectProvider<Gitea> {
+        return gitea(name) {
+            project.configure(it, closure)
+        }
+    }
+
+    fun gitea(name: String, action: Action<Gitea>): NamedDomainObjectProvider<Gitea> {
+        return platforms.maybeRegister(name) { it ->
+            it.hostType.set(HostType.GITEA)
+            action.execute(it)
+        }
+    }
+
+    fun giteaOptions(@DelegatesTo(value = Gitea::class) closure: Closure<*>): Provider<GiteaOptions> {
+        return giteaOptions {
+            project.configure(it, closure)
+        }
+    }
+
+    fun giteaOptions(action: Action<GiteaOptions>): Provider<GiteaOptions> {
+        return configureOptions(GiteaOptions::class) {
+            it.from(this)
+            action.execute(it)
+        }
+    }
+
+
+    // Forgejo
+
+    fun forgejo(@DelegatesTo(value = Gitea::class) closure: Closure<*>): NamedDomainObjectProvider<Gitea> {
+        return forgejo {
+            project.configure(it, closure)
+        }
+    }
+
+    fun forgejo(action: Action<Gitea>): NamedDomainObjectProvider<Gitea> {
+        return forgejo("forgejo", action)
+    }
+
+    fun forgejo(name: String, @DelegatesTo(value = Gitea::class) closure: Closure<*>): NamedDomainObjectProvider<Gitea> {
+        return forgejo(name) {
+            project.configure(it, closure)
+        }
+    }
+
+    fun forgejo(name: String, action: Action<Gitea>): NamedDomainObjectProvider<Gitea> {
+        return platforms.maybeRegister(name) { it ->
+            it.hostType.set(HostType.FORGEJO)
+            action.execute(it)
+        }
+    }
+
+    fun forgejoOptions(@DelegatesTo(value = Gitea::class) closure: Closure<*>): Provider<GiteaOptions> {
+        return giteaOptions {
+            project.configure(it, closure)
+        }
+    }
+
+    fun forgejoOptions(action: Action<GiteaOptions>): Provider<GiteaOptions> {
+        return configureOptions(GiteaOptions::class) {
             it.from(this)
             action.execute(it)
         }

--- a/src/main/kotlin/me/modmuss50/mpp/ModPublishExtension.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/ModPublishExtension.kt
@@ -230,7 +230,7 @@ abstract class ModPublishExtension(val project: Project) : PublishOptions {
     }
 
     fun forgejoOptions(@DelegatesTo(value = Gitea::class) closure: Closure<*>): Provider<GiteaOptions> {
-        return giteaOptions {
+        return forgejoOptions {
             project.configure(it, closure)
         }
     }

--- a/src/main/kotlin/me/modmuss50/mpp/MppPlugin.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/MppPlugin.kt
@@ -1,6 +1,7 @@
 package me.modmuss50.mpp
 
 import me.modmuss50.mpp.platforms.curseforge.Curseforge
+import me.modmuss50.mpp.platforms.gitea.Gitea
 import me.modmuss50.mpp.platforms.github.Github
 import me.modmuss50.mpp.platforms.modrinth.Modrinth
 import org.gradle.api.Plugin
@@ -21,6 +22,9 @@ class MppPlugin : Plugin<Project> {
         }
         extension.platforms.registerFactory(Modrinth::class.java) {
             project.objects.newInstance(Modrinth::class.java, it)
+        }
+        extension.platforms.registerFactory(Gitea::class.java) {
+            project.objects.newInstance(Gitea::class.java, it)
         }
 
         val publishModsTask = project.tasks.register("publishMods") {

--- a/src/main/kotlin/me/modmuss50/mpp/PlatformInternal.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/PlatformInternal.kt
@@ -103,6 +103,22 @@ data class ModrinthPublishResult(
         get() = 0x1BD96A
 }
 
+
+@Serializable
+@SerialName("gitea")
+data class GiteaPublishResult(
+    val repository: String,
+    val releaseId: Long,
+    val url: String,
+    override val title: String,
+    override val brandColor: Int,
+) : PublishResult() {
+    override val type: String
+        get() = "gitea"
+    override val link: String
+        get() = url
+}
+
 @ApiStatus.Internal
 class PublishContext(private val queue: WorkQueue, private val result: RegularFile) {
     fun <T : PublishWorkParameters> submit(workActionClass: KClass<out PublishWorkAction<T>>, parameterAction: Action<in T>) {

--- a/src/main/kotlin/me/modmuss50/mpp/PlatformInternal.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/PlatformInternal.kt
@@ -103,7 +103,6 @@ data class ModrinthPublishResult(
         get() = 0x1BD96A
 }
 
-
 @Serializable
 @SerialName("gitea")
 data class GiteaPublishResult(

--- a/src/main/kotlin/me/modmuss50/mpp/PublishModTask.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/PublishModTask.kt
@@ -93,12 +93,12 @@ abstract class PublishModTask @Inject constructor(@Nested val platform: Platform
             }
         }
 
-		// Repeat the hack for Gitea.
-		if (platform is GiteaOptions) {
-			if (!platform.file.isPresent && platform.allowEmptyFiles.get()) {
-				return
-			}
-		}
+        // Repeat the hack for Gitea.
+        if (platform is GiteaOptions) {
+            if (!platform.file.isPresent && platform.allowEmptyFiles.get()) {
+                return
+            }
+        }
 
         val file = platform.file.get().asFile
 

--- a/src/main/kotlin/me/modmuss50/mpp/PublishModTask.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/PublishModTask.kt
@@ -2,6 +2,7 @@ package me.modmuss50.mpp
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import me.modmuss50.mpp.platforms.gitea.GiteaOptions
 import me.modmuss50.mpp.platforms.github.GithubOptions
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
@@ -85,12 +86,19 @@ abstract class PublishModTask @Inject constructor(@Nested val platform: Platform
     }
 
     private fun dryRunCopyMainFile() {
-        // A bit of a hack to handle the optional main file for Github.
+        // A bit of a hack to handle the optional main file for GitHub.
         if (platform is GithubOptions) {
             if (!platform.file.isPresent && platform.allowEmptyFiles.get()) {
                 return
             }
         }
+
+		// Repeat the hack for Gitea.
+		if (platform is GiteaOptions) {
+			if (!platform.file.isPresent && platform.allowEmptyFiles.get()) {
+				return
+			}
+		}
 
         val file = platform.file.get().asFile
 

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
@@ -11,7 +11,6 @@ import me.modmuss50.mpp.PublishResult
 import me.modmuss50.mpp.PublishWorkAction
 import me.modmuss50.mpp.PublishWorkParameters
 import me.modmuss50.mpp.ReleaseType
-import me.modmuss50.mpp.platforms.gitea.GiteaOptions.HostType
 import org.gradle.api.Task
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
@@ -81,7 +80,7 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
         allowEmptyFiles.convention(false)
     }
 
-    fun hostUrl(task: Provider<String>) {
+    fun host(task: Provider<String>) {
         apiEndpoint.convention(task.get() + "/api/v1")
     }
 
@@ -113,6 +112,10 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
         releaseResult.set(publishTask.flatMap { it.result })
 
         val options = publishTask.map { it.platform as GiteaOptions }
+        if (options.get().hostType.get() != hostType.get()) { // May not be necessary, but should reduce confusion.
+            throw IllegalArgumentException("Unable to parent Gitea with Forgejo, or vice versa.")
+        }
+
         version.set(options.flatMap { it.version })
         version.finalizeValue()
         changelog.set(options.flatMap { it.changelog })
@@ -127,6 +130,10 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
         commitish.finalizeValue()
         tagName.set(options.flatMap { it.tagName })
         tagName.finalizeValue()
+
+        // Include this here to make sure that different hosts may resolve correctly when parenting. This is not included in other platforms.
+        apiEndpoint.set(options.flatMap { it.apiEndpoint })
+        apiEndpoint.finalizeValue()
     }
 
     enum class HostType constructor(val friendlyString: String, val defaultBrandColor: Int) {
@@ -193,7 +200,7 @@ abstract class Gitea @Inject constructor(name: String) : Platform(name), GiteaOp
                 val noneUnique = files.groupingBy { it.name }.eachCount().filter { it.value > 1 }
                 if (noneUnique.isNotEmpty()) {
                     val noneUniqueNames = noneUnique.keys.joinToString(", ")
-                    throw IllegalStateException("$hostDisplayName file names must be unique within a release, found duplicates: $noneUniqueNames")
+                    throw IllegalStateException("${hostType.get().friendlyString} file names must be unique within a release, found duplicates: $noneUniqueNames")
                 }
 
                 for (file in files) {

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
@@ -50,6 +50,20 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
     @get:Input
     val apiEndpoint: Property<String>
 
+	/**
+	 * Specifies the display name for the custom host. For example, Codeberg.
+	 */
+	@get:Input
+	@get:Optional
+	val hostDisplayName: Property<String>
+
+	/**
+	 * Specifies a custom brand color for Discord embeds. Useful for specific hosts.
+	 */
+	@get:Input
+	@get:Optional
+	val hostBrandColor: Property<Int>
+
     @get:Input
     val allowEmptyFiles: Property<Boolean>
 
@@ -58,17 +72,9 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
     @get:Internal
     val releaseResult: RegularFileProperty
 
-    /**
-     * Specifies the display name for the custom host. For example, Codeberg.
-     */
-    @get:Input
-    val hostDisplayName: Property<String>
-
-    /**
-     * Specifies a custom brand color for Discord embeds. Useful for specific hosts.
-     */
-    @get:Input
-    val hostBrandColor: Property<Int>
+	@get:Input
+	@get:Internal
+	val hostType: Property<HostType>
 
     override fun setInternalDefaults() {
         tagName.convention(version)
@@ -87,6 +93,7 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
         apiEndpoint.convention(other.apiEndpoint)
         allowEmptyFiles.convention(other.allowEmptyFiles)
         releaseResult.convention(other.releaseResult)
+		hostType.convention(other.hostType)
     }
 
     fun from(other: Provider<GiteaOptions>) {
@@ -129,13 +136,7 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
     }
 }
 
-interface HostTyped {
-    @get:InputFile
-    @get:Internal
-    val hostType: Property<HostType>
-}
-
-abstract class Gitea @Inject constructor(name: String) : Platform(name), GiteaOptions, HostTyped {
+abstract class Gitea @Inject constructor(name: String) : Platform(name), GiteaOptions {
     override fun publish(context: PublishContext) {
         val files = additionalFiles.files.toMutableList()
 
@@ -172,7 +173,7 @@ abstract class Gitea @Inject constructor(name: String) : Platform(name), GiteaOp
         return name.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }
     }
 
-    interface UploadParams : PublishWorkParameters, GiteaOptions, HostTyped
+    interface UploadParams : PublishWorkParameters, GiteaOptions
 
     abstract class UploadWorkAction : PublishWorkAction<UploadParams> {
         override fun publish(): PublishResult {

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.annotations.ApiStatus.Internal
+import java.net.URI
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.random.Random
@@ -80,8 +81,8 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
         allowEmptyFiles.convention(false)
     }
 
-    fun host(task: Provider<String>) {
-        apiEndpoint.convention(task.get() + "/api/v1")
+    fun host(uri: URI) {
+        apiEndpoint.convention("$uri/api/v1")
     }
 
     fun from(other: GiteaOptions) {
@@ -113,7 +114,7 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
 
         val options = publishTask.map { it.platform as GiteaOptions }
         if (options.get().hostType.get() != hostType.get()) { // May not be necessary, but should reduce confusion.
-            throw IllegalArgumentException("Unable to parent Gitea with Forgejo, or vice versa.")
+            throw IllegalArgumentException("Unable to parent a ${hostType.get()} instance to a ${options.get().hostType.get()} instance")
         }
 
         version.set(options.flatMap { it.version })

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
@@ -205,7 +205,7 @@ abstract class Gitea @Inject constructor(name: String) : Platform(name), GiteaOp
                 }
 
                 for (file in files) {
-                    api.uploadAsset(release,  displayName.get(), file)
+                    api.uploadAsset(release, file)
                 }
 
                 if (created) {

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
@@ -114,7 +114,7 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
 
         val options = publishTask.map { it.platform as GiteaOptions }
         if (options.get().hostType.get() != hostType.get()) { // May not be necessary, but should reduce confusion.
-            throw IllegalArgumentException("Unable to parent a ${hostType.get()} instance to a ${options.get().hostType.get()} instance")
+            throw IllegalStateException("Unable to make a ${options.get().hostType.get().friendlyString} instance a parent of a ${hostType.get().friendlyString} instance")
         }
 
         version.set(options.flatMap { it.version })

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
@@ -50,19 +50,19 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
     @get:Input
     val apiEndpoint: Property<String>
 
-	/**
-	 * Specifies the display name for the custom host. For example, Codeberg.
-	 */
-	@get:Input
-	@get:Optional
-	val hostDisplayName: Property<String>
+    /**
+     * Specifies the display name for the custom host. For example, Codeberg.
+     */
+    @get:Input
+    @get:Optional
+    val hostDisplayName: Property<String>
 
-	/**
-	 * Specifies a custom brand color for Discord embeds. Useful for specific hosts.
-	 */
-	@get:Input
-	@get:Optional
-	val hostBrandColor: Property<Int>
+    /**
+     * Specifies a custom brand color for Discord embeds. Useful for specific hosts.
+     */
+    @get:Input
+    @get:Optional
+    val hostBrandColor: Property<Int>
 
     @get:Input
     val allowEmptyFiles: Property<Boolean>
@@ -72,9 +72,9 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
     @get:Internal
     val releaseResult: RegularFileProperty
 
-	@get:Input
-	@get:Internal
-	val hostType: Property<HostType>
+    @get:Input
+    @get:Internal
+    val hostType: Property<HostType>
 
     override fun setInternalDefaults() {
         tagName.convention(version)
@@ -93,7 +93,7 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
         apiEndpoint.convention(other.apiEndpoint)
         allowEmptyFiles.convention(other.allowEmptyFiles)
         releaseResult.convention(other.releaseResult)
-		hostType.convention(other.hostType)
+        hostType.convention(other.hostType)
     }
 
     fun from(other: Provider<GiteaOptions>) {
@@ -140,7 +140,7 @@ interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> 
     enum class HostType constructor(val friendlyString: String, val defaultBrandColor: Int) {
         GITEA("Gitea", 0x1d8f4a),
 
-        FORGEJO("Forgejo", 0xff5500);
+        FORGEJO("Forgejo", 0xff5500),
     }
 }
 
@@ -170,7 +170,7 @@ abstract class Gitea @Inject constructor(name: String) : Platform(name), GiteaOp
             releaseId = 0,
             url = "https://github.com/modmuss50/mod-publish-plugin/dry-run?random=${Random.nextInt(0, 1000000)}",
             title = announcementTitle.getOrElse("Download from $hostDisplayName"),
-            brandColor = brandColor
+            brandColor = brandColor,
         )
     }
 
@@ -218,7 +218,7 @@ abstract class Gitea @Inject constructor(name: String) : Platform(name), GiteaOp
                     releaseId = release.id,
                     url = release.htmlUrl,
                     title = announcementTitle.getOrElse("Download from $hostDisplayName"),
-                    brandColor = brandColor
+                    brandColor = brandColor,
                 )
             }
         }
@@ -232,14 +232,13 @@ abstract class Gitea @Inject constructor(name: String) : Platform(name), GiteaOp
                     return ReleaseResult(api.getRelease(result.releaseId), false)
                 }
 
-
                 val metadata = GiteaApi.CreateRelease(
                     body = changelog.orNull,
                     draft = true,
                     name = displayName.get(),
                     prerelease = type.get() != ReleaseType.STABLE,
                     tagName = tagName.get(),
-                    targetCommitish = commitish.get()
+                    targetCommitish = commitish.get(),
                 )
 
                 return ReleaseResult(api.createRelease(metadata), true)

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/Gitea.kt
@@ -1,0 +1,240 @@
+package me.modmuss50.mpp.platforms.gitea
+
+import me.modmuss50.mpp.GiteaPublishResult
+import me.modmuss50.mpp.Platform
+import me.modmuss50.mpp.PlatformOptions
+import me.modmuss50.mpp.PlatformOptionsInternal
+import me.modmuss50.mpp.PublishContext
+import me.modmuss50.mpp.PublishModTask
+import me.modmuss50.mpp.PublishOptions
+import me.modmuss50.mpp.PublishResult
+import me.modmuss50.mpp.PublishWorkAction
+import me.modmuss50.mpp.PublishWorkParameters
+import me.modmuss50.mpp.ReleaseType
+import me.modmuss50.mpp.platforms.gitea.GiteaOptions.HostType
+import org.gradle.api.Task
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.logging.Logger
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.annotations.ApiStatus.Internal
+import java.util.Locale
+import javax.inject.Inject
+import kotlin.random.Random
+
+interface GiteaOptions : PlatformOptions, PlatformOptionsInternal<GiteaOptions> {
+    @get:InputFile
+    @get:Optional
+    override val file: RegularFileProperty
+
+    /**
+     * "owner/repo"
+     */
+    @get:Input
+    val repository: Property<String>
+
+    /**
+     * Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA.
+     */
+    @get:Input
+    @get:Optional
+    val commitish: Property<String>
+
+    @get:Input
+    val tagName: Property<String>
+
+    @get:Input
+    val apiEndpoint: Property<String>
+
+    @get:Input
+    val allowEmptyFiles: Property<Boolean>
+
+    @get:InputFile
+    @get:Optional
+    @get:Internal
+    val releaseResult: RegularFileProperty
+
+    /**
+     * Specifies the display name for the custom host. For example, Codeberg.
+     */
+    @get:Input
+    val hostDisplayName: Property<String>
+
+    /**
+     * Specifies a custom brand color for Discord embeds. Useful for specific hosts.
+     */
+    @get:Input
+    val hostBrandColor: Property<Int>
+
+    override fun setInternalDefaults() {
+        tagName.convention(version)
+        allowEmptyFiles.convention(false)
+    }
+
+    fun hostUrl(task: Provider<String>) {
+        apiEndpoint.convention(task.get() + "/api/v1")
+    }
+
+    fun from(other: GiteaOptions) {
+        super.from(other)
+        repository.convention(other.repository)
+        commitish.convention(other.commitish)
+        tagName.convention(other.tagName)
+        apiEndpoint.convention(other.apiEndpoint)
+        allowEmptyFiles.convention(other.allowEmptyFiles)
+        releaseResult.convention(other.releaseResult)
+    }
+
+    fun from(other: Provider<GiteaOptions>) {
+        from(other.get())
+    }
+
+    fun from(other: Provider<GiteaOptions>, publishOptions: Provider<PublishOptions>) {
+        from(other)
+        from(publishOptions.get())
+    }
+
+    /**
+     * Publish to an existing release, created by another task.
+     */
+    fun parent(task: TaskProvider<Task>) {
+        val publishTask = task.map { it as PublishModTask }
+        releaseResult.set(publishTask.flatMap { it.result })
+
+        val options = publishTask.map { it.platform as GiteaOptions }
+        version.set(options.flatMap { it.version })
+        version.finalizeValue()
+        changelog.set(options.flatMap { it.changelog })
+        changelog.finalizeValue()
+        type.set(options.flatMap { it.type })
+        type.finalizeValue()
+        displayName.set(options.flatMap { it.displayName })
+        displayName.finalizeValue()
+        repository.set(options.flatMap { it.repository })
+        repository.finalizeValue()
+        commitish.set(options.flatMap { it.commitish })
+        commitish.finalizeValue()
+        tagName.set(options.flatMap { it.tagName })
+        tagName.finalizeValue()
+    }
+
+    enum class HostType constructor(val friendlyString: String, val defaultBrandColor: Int) {
+        GITEA("Gitea", 0x1d8f4a),
+
+        FORGEJO("Forgejo", 0xff5500);
+    }
+}
+
+interface HostTyped {
+    @get:InputFile
+    @get:Internal
+    val hostType: Property<HostType>
+}
+
+abstract class Gitea @Inject constructor(name: String) : Platform(name), GiteaOptions, HostTyped {
+    override fun publish(context: PublishContext) {
+        val files = additionalFiles.files.toMutableList()
+
+        if (file.isPresent) {
+            files.add(file.get().asFile)
+        }
+
+        if (files.isEmpty() && !allowEmptyFiles.get()) {
+            throw IllegalStateException("No files to upload to ${capitalizedName()}.")
+        }
+
+        context.submit(UploadWorkAction::class) {
+            it.from(this)
+        }
+    }
+
+    override fun dryRunPublishResult(): PublishResult {
+        val hostDisplayName = hostDisplayName.getOrElse(hostType.get().friendlyString)
+        val brandColor = hostBrandColor.getOrElse(hostType.get().defaultBrandColor)
+
+        return GiteaPublishResult(
+            repository = repository.get(),
+            releaseId = 0,
+            url = "https://github.com/modmuss50/mod-publish-plugin/dry-run?random=${Random.nextInt(0, 1000000)}",
+            title = announcementTitle.getOrElse("Download from $hostDisplayName"),
+            brandColor = brandColor
+        )
+    }
+
+    override fun printDryRunInfo(logger: Logger) {
+    }
+
+    fun capitalizedName(): String {
+        return name.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }
+    }
+
+    interface UploadParams : PublishWorkParameters, GiteaOptions, HostTyped
+
+    abstract class UploadWorkAction : PublishWorkAction<UploadParams> {
+        override fun publish(): PublishResult {
+            with(parameters) {
+                val hostDisplayName = hostDisplayName.getOrElse(hostType.get().friendlyString)
+                val brandColor = hostBrandColor.getOrElse(hostType.get().defaultBrandColor)
+
+                val api = GiteaApi(accessToken.get(), apiEndpoint.get(), repository.get())
+                val (release, created) = getOrCreateRelease(api)
+
+                val files = additionalFiles.files.toMutableList()
+
+                if (file.isPresent) {
+                    files.add(file.get().asFile)
+                }
+
+                val noneUnique = files.groupingBy { it.name }.eachCount().filter { it.value > 1 }
+                if (noneUnique.isNotEmpty()) {
+                    val noneUniqueNames = noneUnique.keys.joinToString(", ")
+                    throw IllegalStateException("$hostDisplayName file names must be unique within a release, found duplicates: $noneUniqueNames")
+                }
+
+                for (file in files) {
+                    api.uploadAsset(release,  displayName.get(), file)
+                }
+
+                if (created) {
+                    // Publish the release after all assets are uploaded.
+                    api.publishRelease(release)
+                }
+
+                return GiteaPublishResult(
+                    repository = repository.get(),
+                    releaseId = release.id,
+                    url = release.htmlUrl,
+                    title = announcementTitle.getOrElse("Download from $hostDisplayName"),
+                    brandColor = brandColor
+                )
+            }
+        }
+
+        data class ReleaseResult(val release: GiteaApi.Release, val created: Boolean)
+
+        private fun getOrCreateRelease(api: GiteaApi): ReleaseResult {
+            with(parameters) {
+                if (releaseResult.isPresent) {
+                    val result = PublishResult.fromJson(releaseResult.get().asFile.readText()) as GiteaPublishResult
+                    return ReleaseResult(api.getRelease(result.releaseId), false)
+                }
+
+
+                val metadata = GiteaApi.CreateRelease(
+                    body = changelog.orNull,
+                    draft = true,
+                    name = displayName.get(),
+                    prerelease = type.get() != ReleaseType.STABLE,
+                    tagName = tagName.get(),
+                    targetCommitish = commitish.get()
+                )
+
+                return ReleaseResult(api.createRelease(metadata), true)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/GiteaApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/GiteaApi.kt
@@ -60,12 +60,12 @@ class GiteaApi(private val accessToken: String, private val baseUrl: String, pri
         return httpUtils.get("$baseUrl/repos/$repository/releases/$id", headers)
     }
 
-    fun uploadAsset(release: Release, name: String, file: File) {
+    fun uploadAsset(release: Release, file: File) {
         val mediaType = "application/java-archive".toMediaTypeOrNull()
 
         val bodyBuilder = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
-            .addFormDataPart("attachment", name, file.asRequestBody(mediaType))
+            .addFormDataPart("attachment", file.name, file.asRequestBody(mediaType))
 
         return httpUtils.post(release.uploadUrl, bodyBuilder.build(), headers)
     }

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/GiteaApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/GiteaApi.kt
@@ -19,6 +19,7 @@ class GiteaApi(private val accessToken: String, private val baseUrl: String, pri
     )
 
     @Serializable
+    // https://docs.gitea.com/api/1.24/#tag/repository/operation/repoGetRelease
     data class Release(
         val id: Long,
         @SerialName("html_url")
@@ -28,6 +29,7 @@ class GiteaApi(private val accessToken: String, private val baseUrl: String, pri
     )
 
     // Some of the below are nullable, but we don't need their nullability here.
+    // https://docs.gitea.com/api/1.24/#tag/repository/operation/repoCreateRelease
     @Serializable
     data class CreateRelease(
         val body: String? = null,
@@ -39,6 +41,7 @@ class GiteaApi(private val accessToken: String, private val baseUrl: String, pri
         val targetCommitish: String,
     )
 
+    // Error responses are consistent between hooks.
     @Serializable
     data class ErrorResponse(
         val message: String,
@@ -83,6 +86,7 @@ class GiteaApi(private val accessToken: String, private val baseUrl: String, pri
         return httpUtils.patch("$baseUrl/repos/$repository/releases/${release.id}", body, headers)
     }
 
+    // Error responses are consistent between hooks.
     private class GiteaHttpExceptionFactory : HttpUtils.HttpExceptionFactory {
         val json = Json { ignoreUnknownKeys = true }
 

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/GiteaApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/GiteaApi.kt
@@ -47,7 +47,7 @@ class GiteaApi(private val accessToken: String, private val baseUrl: String, pri
 
     private val headers: Map<String, String>
         get() = mapOf(
-            "AuthorizationHeaderToken" to "Token $accessToken",
+            "Authorization" to "token $accessToken",
             "Content-Type" to "application/json",
         )
 

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/GiteaApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/GiteaApi.kt
@@ -51,15 +51,18 @@ class GiteaApi(private val accessToken: String, private val baseUrl: String, pri
             "Content-Type" to "application/json",
         )
 
+    // https://docs.gitea.com/api/1.24/#tag/repository/operation/repoCreateRelease
     fun createRelease(metadata: CreateRelease): Release {
         val body = Json.encodeToString(metadata).toRequestBody()
         return httpUtils.post("$baseUrl/repos/$repository/releases", body, headers)
     }
 
+    // https://docs.gitea.com/api/1.24/#tag/repository/operation/repoGetRelease
     fun getRelease(id: Long): Release {
         return httpUtils.get("$baseUrl/repos/$repository/releases/$id", headers)
     }
 
+    // https://docs.gitea.com/api/1.24/#tag/repository/operation/repoCreateReleaseAttachment
     fun uploadAsset(release: Release, file: File) {
         val mediaType = "application/java-archive".toMediaTypeOrNull()
 
@@ -70,6 +73,7 @@ class GiteaApi(private val accessToken: String, private val baseUrl: String, pri
         return httpUtils.post(release.uploadUrl, bodyBuilder.build(), headers)
     }
 
+    // https://docs.gitea.com/api/1.24/#tag/repository/operation/repoEditRelease
     fun publishRelease(release: Release) {
         val body = """
             {

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/GiteaApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/GiteaApi.kt
@@ -1,0 +1,94 @@
+package me.modmuss50.mpp.platforms.gitea
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import me.modmuss50.mpp.HttpUtils
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import java.io.File
+
+class GiteaApi(private val accessToken: String, private val baseUrl: String, private val repository: String) {
+    private val httpUtils = HttpUtils(
+        exceptionFactory = GiteaHttpExceptionFactory(),
+    )
+
+    @Serializable
+    data class Release(
+        val id: Long,
+        @SerialName("html_url")
+        val htmlUrl: String,
+        @SerialName("upload_url")
+        val uploadUrl: String,
+    )
+
+    // Some of the below are nullable, but we don't need their nullability here.
+    @Serializable
+    data class CreateRelease(
+        val body: String? = null,
+        val draft: Boolean,
+        val name: String? = null,
+        val prerelease: Boolean,
+        @SerialName("tag_name")
+        val tagName: String,
+        val targetCommitish: String,
+    )
+
+    @Serializable
+    data class ErrorResponse(
+        val message: String,
+        val url: String,
+    )
+
+    private val headers: Map<String, String>
+        get() = mapOf(
+            "AuthorizationHeaderToken" to "Token $accessToken",
+            "Content-Type" to "application/json",
+        )
+
+    fun createRelease(metadata: CreateRelease): Release {
+        val body = Json.encodeToString(metadata).toRequestBody()
+        return httpUtils.post("$baseUrl/repos/$repository/releases", body, headers)
+    }
+
+    fun getRelease(id: Long): Release {
+        return httpUtils.get("$baseUrl/repos/$repository/releases/$id", headers)
+    }
+
+    fun uploadAsset(release: Release, name: String, file: File) {
+        val mediaType = "application/java-archive".toMediaTypeOrNull()
+
+        val bodyBuilder = MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("attachment", name, file.asRequestBody(mediaType))
+
+        return httpUtils.post(release.uploadUrl, bodyBuilder.build(), headers)
+    }
+
+    fun publishRelease(release: Release) {
+        val body = """
+            {
+            "draft": false
+            }
+        """.trimIndent().toRequestBody()
+        return httpUtils.patch("$baseUrl/repos/$repository/releases/${release.id}", body, headers)
+    }
+
+    private class GiteaHttpExceptionFactory : HttpUtils.HttpExceptionFactory {
+        val json = Json { ignoreUnknownKeys = true }
+
+        override fun createException(response: Response): HttpUtils.HttpException {
+            return try {
+                val errorResponse = json.decodeFromString<ErrorResponse>(response.body!!.string())
+                HttpUtils.HttpException(response, errorResponse.message)
+            } catch (e: SerializationException) {
+                HttpUtils.HttpException(response, "Unknown error")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitea/GiteaTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitea/GiteaTest.kt
@@ -6,6 +6,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class GiteaTest : IntegrationTest {
     @Test
@@ -254,8 +255,7 @@ class GiteaTest : IntegrationTest {
             .run("publishGitea")
         server.close()
 
-        // TODO: This will always throw an exception and fail. I don't really know how to fix it. - Calico
-        assertEquals(TaskOutcome.FAILED, result.task(":publishGitea")!!.outcome)
+        assertNull(result.task(":publishGitea"))
         assertContains(result.output, "Unable to make a Gitea instance a parent of a Forgejo instance")
     }
 }

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitea/GiteaTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitea/GiteaTest.kt
@@ -22,9 +22,9 @@ class GiteaTest : IntegrationTest {
                         type = STABLE
                         gitea {
                             accessToken = "123"
+                            host("${server.endpoint}")
                             repository = "test/example"
                             commitish = "main"
-                            apiEndpoint = "${server.endpoint}"
                             tagName = "release/1.0.0"
                         }
                     }
@@ -50,9 +50,9 @@ class GiteaTest : IntegrationTest {
                         type = STABLE
                         forgejo {
                             accessToken = "123"
+                            host("${server.endpoint}")
                             repository = "test/example"
                             commitish = "main"
-                            apiEndpoint = "${server.endpoint}"
                             tagName = "release/1.0.0"
                         }
                     }
@@ -77,9 +77,9 @@ class GiteaTest : IntegrationTest {
                         type = STABLE
                         gitea {
                             accessToken = "123"
+                            host("${server.endpoint}")
                             repository = "test/example"
                             commitish = "main"
-                            apiEndpoint = "${server.endpoint}"
                             tagName = "release/1.0.0"
                             additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
                         }
@@ -106,14 +106,14 @@ class GiteaTest : IntegrationTest {
                         type = STABLE
                         gitea {
                             accessToken = "123"
+                            host("${server.endpoint}")
                             repository = "test/example"
                             commitish = "main"
-                            apiEndpoint = "${server.endpoint}"
                             tagName = "release/1.0.0"
                         }
                         gitea("giteaOther") {
+                            host("${server.endpoint}")
                             accessToken = "123"
-                            apiEndpoint = "${server.endpoint}"
                             parent(tasks.named("publishGitea"))
                         }
                     }
@@ -138,9 +138,9 @@ class GiteaTest : IntegrationTest {
                         type = STABLE
                         gitea {
                             accessToken = "123"
+                            host("${server.endpoint}")
                             repository = "test/example"
                             commitish = "main"
-                            apiEndpoint = "${server.endpoint}"
                             tagName = "release/1.0.0"
                             allowEmptyFiles = true
                         }
@@ -153,7 +153,7 @@ class GiteaTest : IntegrationTest {
                     publishMods {
                         gitea {
                             accessToken = "123"
-                            apiEndpoint = "${server.endpoint}"
+                            host("${server.endpoint}")
                             parent(project(":").tasks.named("publishGitea"))
                             file = tasks.jar.flatMap { it.archiveFile }
                         }
@@ -181,9 +181,9 @@ class GiteaTest : IntegrationTest {
                         dryRun = true
                         gitea {
                             accessToken = "123"
+                            host("${server.endpoint}")
                             repository = "test/example"
                             commitish = "main"
-                            apiEndpoint = "${server.endpoint}"
                             tagName = "release/1.0.0"
                             allowEmptyFiles = true
                         }
@@ -210,9 +210,9 @@ class GiteaTest : IntegrationTest {
                         type = STABLE
                         gitea {
                             accessToken = "123"
+                            host("${server.endpoint}")
                             repository = "test/example"
                             commitish = "main"
-                            apiEndpoint = "${server.endpoint}"
                             tagName = "release/1.0.0"
                             additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
                         }

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitea/GiteaTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitea/GiteaTest.kt
@@ -22,7 +22,7 @@ class GiteaTest : IntegrationTest {
                         type = STABLE
                         gitea {
                             accessToken = "123"
-                            host("${server.endpoint}")
+                            host(uri("${server.endpoint}"))
                             repository = "test/example"
                             commitish = "main"
                             tagName = "release/1.0.0"
@@ -50,7 +50,7 @@ class GiteaTest : IntegrationTest {
                         type = STABLE
                         forgejo {
                             accessToken = "123"
-                            host("${server.endpoint}")
+                            host(uri("${server.endpoint}"))
                             repository = "test/example"
                             commitish = "main"
                             tagName = "release/1.0.0"
@@ -77,7 +77,7 @@ class GiteaTest : IntegrationTest {
                         type = STABLE
                         gitea {
                             accessToken = "123"
-                            host("${server.endpoint}")
+                            host(uri("${server.endpoint}"))
                             repository = "test/example"
                             commitish = "main"
                             tagName = "release/1.0.0"
@@ -106,13 +106,12 @@ class GiteaTest : IntegrationTest {
                         type = STABLE
                         gitea {
                             accessToken = "123"
-                            host("${server.endpoint}")
+                            host(uri("${server.endpoint}"))
                             repository = "test/example"
                             commitish = "main"
                             tagName = "release/1.0.0"
                         }
                         gitea("giteaOther") {
-                            host("${server.endpoint}")
                             accessToken = "123"
                             parent(tasks.named("publishGitea"))
                         }
@@ -138,7 +137,7 @@ class GiteaTest : IntegrationTest {
                         type = STABLE
                         gitea {
                             accessToken = "123"
-                            host("${server.endpoint}")
+                            host(uri("${server.endpoint}"))
                             repository = "test/example"
                             commitish = "main"
                             tagName = "release/1.0.0"
@@ -153,7 +152,6 @@ class GiteaTest : IntegrationTest {
                     publishMods {
                         gitea {
                             accessToken = "123"
-                            host("${server.endpoint}")
                             parent(project(":").tasks.named("publishGitea"))
                             file = tasks.jar.flatMap { it.archiveFile }
                         }
@@ -181,7 +179,7 @@ class GiteaTest : IntegrationTest {
                         dryRun = true
                         gitea {
                             accessToken = "123"
-                            host("${server.endpoint}")
+                            host(uri("${server.endpoint}"))
                             repository = "test/example"
                             commitish = "main"
                             tagName = "release/1.0.0"
@@ -210,7 +208,7 @@ class GiteaTest : IntegrationTest {
                         type = STABLE
                         gitea {
                             accessToken = "123"
-                            host("${server.endpoint}")
+                            host(uri("${server.endpoint}"))
                             repository = "test/example"
                             commitish = "main"
                             tagName = "release/1.0.0"
@@ -224,5 +222,39 @@ class GiteaTest : IntegrationTest {
 
         assertEquals(TaskOutcome.FAILED, result.task(":publishGitea")!!.outcome)
         assertContains(result.output, "Gitea file names must be unique within a release, found duplicates: mpp-example.jar")
+    }
+
+    @Test
+    fun failOnParentingGiteaWithForgejo() {
+        val server = MockWebServer(MockGiteaApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        gitea {
+                            accessToken = "123"
+                            host(uri("${server.endpoint}"))
+                            repository = "test/example"
+                            commitish = "main"
+                            tagName = "release/1.0.0"
+                            additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
+                        }
+                        forgejo {
+                            accessToken = "123"
+                            parent(tasks.named("publishGitea"))
+                        }
+                    }
+                """.trimIndent(),
+            )
+            .run("publishGitea")
+        server.close()
+
+        assertEquals(TaskOutcome.FAILED, result.task(":publishGitea")!!.outcome)
+        assertContains(result.output, "Unable to parent a Forgejo instance to a Gitea instance")
     }
 }

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitea/GiteaTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitea/GiteaTest.kt
@@ -1,0 +1,228 @@
+package me.modmuss50.mpp.test.gitea
+
+import me.modmuss50.mpp.test.IntegrationTest
+import me.modmuss50.mpp.test.MockWebServer
+import org.gradle.testkit.runner.TaskOutcome
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class GiteaTest : IntegrationTest {
+    @Test
+    fun uploadGitea() {
+        val server = MockWebServer(MockGiteaApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        gitea {
+                            accessToken = "123"
+                            repository = "test/example"
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                            tagName = "release/1.0.0"
+                        }
+                    }
+                """.trimIndent(),
+            )
+            .run("publishGitea")
+        server.close()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitea")!!.outcome)
+    }
+
+    @Test
+    fun uploadForgejo() {
+        val server = MockWebServer(MockGiteaApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        forgejo {
+                            accessToken = "123"
+                            repository = "test/example"
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                            tagName = "release/1.0.0"
+                        }
+                    }
+                """.trimIndent(),
+            )
+            .run("publishForgejo")
+        server.close()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishForgejo")!!.outcome)
+    }
+
+    @Test
+    fun noMainFile() {
+        val server = MockWebServer(MockGiteaApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                    publishMods {
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        gitea {
+                            accessToken = "123"
+                            repository = "test/example"
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                            tagName = "release/1.0.0"
+                            additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
+                        }
+                    }
+                """.trimIndent(),
+            )
+            .run("publishGitea")
+        server.close()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitea")!!.outcome)
+    }
+
+    @Test
+    fun uploadGiteaExistingRelease() {
+        val server = MockWebServer(MockGiteaApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        gitea {
+                            accessToken = "123"
+                            repository = "test/example"
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                            tagName = "release/1.0.0"
+                        }
+                        gitea("giteaOther") {
+                            accessToken = "123"
+                            apiEndpoint = "${server.endpoint}"
+                            parent(tasks.named("publishGitea"))
+                        }
+                    }
+                """.trimIndent(),
+            )
+            .run("publishGiteaOther")
+        server.close()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishGiteaOther")!!.outcome)
+    }
+
+    @Test
+    fun allowEmptyFiles() {
+        val server = MockWebServer(MockGiteaApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                    publishMods {
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        gitea {
+                            accessToken = "123"
+                            repository = "test/example"
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                            tagName = "release/1.0.0"
+                            allowEmptyFiles = true
+                        }
+                    }
+                """.trimIndent(),
+            )
+            .subProject(
+                "child",
+                """
+                    publishMods {
+                        gitea {
+                            accessToken = "123"
+                            apiEndpoint = "${server.endpoint}"
+                            parent(project(":").tasks.named("publishGitea"))
+                            file = tasks.jar.flatMap { it.archiveFile }
+                        }
+                    }
+                """.trimIndent(),
+            )
+            .run("publishMods")
+        server.close()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitea")!!.outcome)
+        assertEquals(TaskOutcome.SUCCESS, result.task(":child:publishGitea")!!.outcome)
+    }
+
+    @Test
+    fun allowEmptyFilesDryRun() {
+        val server = MockWebServer(MockGiteaApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                    publishMods {
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        dryRun = true
+                        gitea {
+                            accessToken = "123"
+                            repository = "test/example"
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                            tagName = "release/1.0.0"
+                            allowEmptyFiles = true
+                        }
+                    }
+                """.trimIndent(),
+            )
+            .run("publishGitea")
+        server.close()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitea")!!.outcome)
+    }
+
+    @Test
+    fun failOnDuplicateNames() {
+        val server = MockWebServer(MockGiteaApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        gitea {
+                            accessToken = "123"
+                            repository = "test/example"
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                            tagName = "release/1.0.0"
+                            additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
+                        }
+                    }
+                """.trimIndent(),
+            )
+            .run("publishGitea")
+        server.close()
+
+        assertEquals(TaskOutcome.FAILED, result.task(":publishGitea")!!.outcome)
+        assertContains(result.output, "Gitea file names must be unique within a release, found duplicates: mpp-example.jar")
+    }
+}

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitea/GiteaTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitea/GiteaTest.kt
@@ -254,7 +254,8 @@ class GiteaTest : IntegrationTest {
             .run("publishGitea")
         server.close()
 
+        // TODO: This will always throw an exception and fail. I don't really know how to fix it. - Calico
         assertEquals(TaskOutcome.FAILED, result.task(":publishGitea")!!.outcome)
-        assertContains(result.output, "Unable to parent a Forgejo instance to a Gitea instance")
+        assertContains(result.output, "Unable to make a Gitea instance a parent of a Forgejo instance")
     }
 }

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitea/MockGiteaApi.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitea/MockGiteaApi.kt
@@ -32,7 +32,7 @@ class MockGiteaApi : MockWebServer.MockApi {
             """
             {
             "id": 1,
-            "upload_url": "http://localhost:${context.port()}/repos/${context.pathParam("owner")}/${context.pathParam("name")}/releases/1/assets",
+            "upload_url": "http://localhost:${context.port()}/api/v1/repos/${context.pathParam("owner")}/${context.pathParam("name")}/releases/1/assets",
             "html_url": "https://codeberg.org"
             }
             """.trimIndent(),
@@ -56,7 +56,7 @@ class MockGiteaApi : MockWebServer.MockApi {
             """
             {
             "id": $id,
-            "upload_url": "http://localhost:${context.port()}/repos/${context.pathParam("owner")}/${context.pathParam("name")}/releases/${id}/assets",
+            "upload_url": "http://localhost:${context.port()}/api/v1/repos/${context.pathParam("owner")}/${context.pathParam("name")}/releases/${id}/assets",
             "html_url": "https://codeberg.org"
             }
             """.trimIndent(),

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitea/MockGiteaApi.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitea/MockGiteaApi.kt
@@ -1,4 +1,4 @@
-package me.modmuss50.mpp.test.gitea;
+package me.modmuss50.mpp.test.gitea
 
 import io.javalin.apibuilder.ApiBuilder.get
 import io.javalin.apibuilder.ApiBuilder.patch
@@ -56,7 +56,7 @@ class MockGiteaApi : MockWebServer.MockApi {
             """
             {
             "id": $id,
-            "upload_url": "http://localhost:${context.port()}/api/v1/repos/${context.pathParam("owner")}/${context.pathParam("name")}/releases/${id}/assets",
+            "upload_url": "http://localhost:${context.port()}/api/v1/repos/${context.pathParam("owner")}/${context.pathParam("name")}/releases/$id/assets",
             "html_url": "https://codeberg.org"
             }
             """.trimIndent(),
@@ -73,4 +73,3 @@ class MockGiteaApi : MockWebServer.MockApi {
         )
     }
 }
-

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitea/MockGiteaApi.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitea/MockGiteaApi.kt
@@ -11,7 +11,7 @@ import me.modmuss50.mpp.test.MockWebServer
 class MockGiteaApi : MockWebServer.MockApi {
     override fun routes(): EndpointGroup {
         return EndpointGroup {
-            path("repos") {
+            path("api/v1/repos") {
                 path("{owner}/{name}") {
                     path("releases") {
                         post(this::createRelease)

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitea/MockGiteaApi.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitea/MockGiteaApi.kt
@@ -32,6 +32,7 @@ class MockGiteaApi : MockWebServer.MockApi {
             """
             {
             "id": 1,
+            "upload_url": "http://localhost:${context.port()}/repos/${context.pathParam("owner")}/${context.pathParam("name")}/releases/1/assets",
             "html_url": "https://codeberg.org"
             }
             """.trimIndent(),

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitea/MockGiteaApi.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitea/MockGiteaApi.kt
@@ -1,0 +1,75 @@
+package me.modmuss50.mpp.test.gitea;
+
+import io.javalin.apibuilder.ApiBuilder.get
+import io.javalin.apibuilder.ApiBuilder.patch
+import io.javalin.apibuilder.ApiBuilder.path
+import io.javalin.apibuilder.ApiBuilder.post
+import io.javalin.apibuilder.EndpointGroup
+import io.javalin.http.Context
+import me.modmuss50.mpp.test.MockWebServer
+
+class MockGiteaApi : MockWebServer.MockApi {
+    override fun routes(): EndpointGroup {
+        return EndpointGroup {
+            path("repos") {
+                path("{owner}/{name}") {
+                    path("releases") {
+                        post(this::createRelease)
+                        path("{id}/assets") {
+                            post(this::uploadAsset)
+                        }
+                        get("{id}", this::getRelease)
+                        patch("{id}", this::updateRelease)
+                    }
+                }
+            }
+        }
+    }
+
+    // https://docs.gitea.com/api/1.24/#tag/repository/operation/repoCreateRelease
+    private fun createRelease(context: Context) {
+        context.result(
+            """
+            {
+            "id": 1,
+            "html_url": "https://codeberg.org"
+            }
+            """.trimIndent(),
+        )
+    }
+
+    // https://docs.gitea.com/api/1.24/#tag/repository/operation/repoCreateReleaseAttachment
+    private fun uploadAsset(context: Context) {
+        context.result(
+            """
+            {
+            }
+            """.trimIndent(),
+        )
+    }
+
+    // https://docs.gitea.com/api/1.24/#tag/repository/operation/repoGetRelease
+    private fun getRelease(context: Context) {
+        val id = context.pathParam("id")
+        context.result(
+            """
+            {
+            "id": $id,
+            "upload_url": "http://localhost:${context.port()}/repos/${context.pathParam("owner")}/${context.pathParam("name")}/releases/${id}/assets",
+            "html_url": "https://codeberg.org"
+            }
+            """.trimIndent(),
+        )
+    }
+
+    // https://docs.gitea.com/api/1.24/#tag/repository/operation/repoEditRelease
+    private fun updateRelease(context: Context) {
+        context.result(
+            """
+            {
+            }
+            """.trimIndent(),
+        )
+    }
+}
+


### PR DESCRIPTION
Resolves #76 

This PR adds the ability to use Gitea or Forgejo (same internals, but flavoured internally depending on which extension method you use). This also exposes some extra internals to allow users to match their host (for example, Forgejo's own Codeberg).

I wouldn't be surprised if you could use the Gitea/Forgejo internals as a basis for non-library GitHub as well, but that's a TODO for later.

## Examples
[An example Forgejo block for a Fabric only mod may be found here](https://git.greenhouse.lgbt/Calico/variant-lib-nature-showcase/src/commit/3802d9a50f8b51850e2908ac17c70964ede9c58b/build.gradle.kts#L118).

[An example Forgejo upload from a local machine may be found here](https://git.greenhouse.lgbt/Modding/greenhouse-multiloader-template/releases/tag/1.0.0-forgejo.local.1+1.21.8).

[A working Forgejo Action may be found here](https://git.greenhouse.lgbt/Calico/variant-lib-nature-showcase/actions/runs/25).

