### PR TITLE
FEATURE: Upstream GitLab support

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -3,7 +3,7 @@
 A modern Gradle plugin to publish Minecraft mods to a range of destinations. Start with the [Getting Started](/getting_started) page.
 
 ### Features
-- Supports CurseForge, Modrinth, Github, Gitea, Forgejo and Discord
+- Supports CurseForge, Modrinth, Github, Gitea, GitLab, Forgejo, and Discord
 - Typesafe DSL to easily publish to multiple locations with minimal repetition
 - Retry on failure
 - Dry run mode to try and increase confidence in your buildscript before releases

--- a/docs/pages/platforms/gitlab.mdx
+++ b/docs/pages/platforms/gitlab.mdx
@@ -1,6 +1,6 @@
 ## Basic example
 See the following minimal example showing how to publish the `jar` task to GitLab:
-```kotlin
+```groovy
 publishMods {
     file = tasks.named<Jar>("jar").flatMap { it.archiveFile }
     changelog = "Changelog"
@@ -10,21 +10,22 @@ publishMods {
     gitlab {
         accessToken = providers.environmentVariable("GITLAB_TOKEN")
         projectId = 12345678 // This is how GitLab resolves the project you are publishing to
-        commitish.set("main") // This is the branch the release tag will be created from
+        commitish = "main" // This is the branch the release tag will be created from
     }
 }
+
 ```
 
 ## Multiple releases
 You can create multiple GitLab destinations by specifying a name like so:
-```kotlin
+```groovy
 publishMods {
     gitlab("A") {
-         // Configure gitlab settings for project A here
+            // Configure gitlab settings for project A here
     }
 
     gitlab("B") {
-        // Configure gitlab settings for project B here
+           // Configure gitlab settings for project B here
     }
 }
 ```
@@ -35,7 +36,7 @@ If you wish to upload files to a GitLab release created by another task either i
 This is useful where you have multiple subprojects that you want to publish to a single release, the following example shows how a root project can create the release and subprojects can upload files to it:
 
 #### Root project
-```kotlin
+```groovy
 publishMods {
     gitlab {
         accessToken = providers.environmentVariable("GITLAB_TOKEN")
@@ -50,35 +51,36 @@ publishMods {
 
 #### Subproject
 When using the `parent` option, only the `accessToken` and files are required, the other options are forcefully inherited from the parent task.
-```kotlin
+```groovy
 publishMods {
     gitlab {
         accessToken = providers.environmentVariable("GITLAB_TOKEN")
 
         // Specify the root project's gitlab task to upload files to
-        parent(project(":").tasks.named("gitlab"))
+        parent project(":").tasks.named("gitlab")
     }
 }
 ```
 
 ## All options
 See the following example showing all the GitLab specific options:
-```kotlin
+```groovy
 publishMods {
     gitlab {
         accessToken = providers.environmentVariable("GITLAB_TOKEN")
         commitish = "main"
         tagName = "TEST_TAG"
 
-        // Optionally set the announcement title used by the discord publisher
-        announcementTitle = "Download from GitLab"
+       // Optionally set the announcement title used by the discord publisher
+       announcementTitle = "Download from GitLab"
 
         // Upload the files to a previously created release, by providing another gitlab publish task
         // This is useful in multi-project builds where you want to publish multiple subprojects to a single release
-        parent(tasks.named("publishGitlab"))
+        parent tasks.named("publishGitlab")
 
         // Optionally allow the release to be created without any attached files.
         // This is useful when you have subprojects using the parent option that you want to publish a single release.
         allowEmptyFiles = true
     }
 }
+```

--- a/docs/pages/platforms/gitlab.mdx
+++ b/docs/pages/platforms/gitlab.mdx
@@ -5,6 +5,7 @@ publishMods {
     file = tasks.named<Jar>("jar").flatMap { it.archiveFile }
     changelog = "Changelog"
     type = STABLE
+    modLoaders.add("fabric")
 
     gitlab {
         accessToken = providers.environmentVariable("GITLAB_TOKEN")

--- a/docs/pages/platforms/gitlab.mdx
+++ b/docs/pages/platforms/gitlab.mdx
@@ -2,7 +2,7 @@
 See the following minimal example showing how to publish the `jar` task to GitLab:
 ```groovy
 publishMods {
-    file = tasks.named<Jar>("jar").flatMap { it.archiveFile }
+    file = tasks.named("jar").flatMap { it.archiveFile }
     changelog = "Changelog"
     type = STABLE
     modLoaders.add("fabric")
@@ -13,7 +13,6 @@ publishMods {
         commitish = "main" // This is the branch the release tag will be created from
     }
 }
-
 ```
 
 ## Multiple releases
@@ -57,7 +56,7 @@ publishMods {
         accessToken = providers.environmentVariable("GITLAB_TOKEN")
 
         // Specify the root project's gitlab task to upload files to
-        parent project(":").tasks.named("gitlab")
+        parent project(":").tasks.named("publishGitlab")
     }
 }
 ```

--- a/docs/pages/platforms/gitlab.mdx
+++ b/docs/pages/platforms/gitlab.mdx
@@ -1,0 +1,83 @@
+## Basic example
+See the following minimal example showing how to publish the `jar` task to GitLab:
+```kotlin
+publishMods {
+    file = tasks.named<Jar>("jar").flatMap { it.archiveFile }
+    changelog = "Changelog"
+    type = STABLE
+
+    gitlab {
+        accessToken = providers.environmentVariable("GITLAB_TOKEN")
+        projectId = 12345678 // This is how GitLab resolves the project you are publishing to
+        commitish.set("main") // This is the branch the release tag will be created from
+    }
+}
+```
+
+## Multiple releases
+You can create multiple GitLab destinations by specifying a name like so:
+```kotlin
+publishMods {
+    gitlab("A") {
+         // Configure gitlab settings for project A here
+    }
+
+    gitlab("B") {
+        // Configure gitlab settings for project B here
+    }
+}
+```
+This will create 2 separate GitLab releases.
+
+## Parent releases
+If you wish to upload files to a GitLab release created by another task either in the same project or another subproject, you can use the `parent` option.
+This is useful where you have multiple subprojects that you want to publish to a single release, the following example shows how a root project can create the release and subprojects can upload files to it:
+
+#### Root project
+```kotlin
+publishMods {
+    gitlab {
+        accessToken = providers.environmentVariable("GITLAB_TOKEN")
+        commitish = "main"
+        tagName = "TEST_TAG"
+
+        // Allow the release to be initially created without any files.
+        allowEmptyFiles = true
+    }
+}
+```
+
+#### Subproject
+When using the `parent` option, only the `accessToken` and files are required, the other options are forcefully inherited from the parent task.
+```kotlin
+publishMods {
+    gitlab {
+        accessToken = providers.environmentVariable("GITLAB_TOKEN")
+
+        // Specify the root project's gitlab task to upload files to
+        parent(project(":").tasks.named("gitlab"))
+    }
+}
+```
+
+## All options
+See the following example showing all the GitLab specific options:
+```kotlin
+publishMods {
+    gitlab {
+        accessToken = providers.environmentVariable("GITLAB_TOKEN")
+        commitish = "main"
+        tagName = "TEST_TAG"
+
+        // Optionally set the announcement title used by the discord publisher
+        announcementTitle = "Download from GitLab"
+
+        // Upload the files to a previously created release, by providing another gitlab publish task
+        // This is useful in multi-project builds where you want to publish multiple subprojects to a single release
+        parent(tasks.named("publishGitlab"))
+
+        // Optionally allow the release to be created without any attached files.
+        // This is useful when you have subprojects using the parent option that you want to publish a single release.
+        allowEmptyFiles = true
+    }
+}

--- a/src/main/kotlin/me/modmuss50/mpp/HttpUtils.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/HttpUtils.kt
@@ -44,6 +44,7 @@ class HttpUtils(val exceptionFactory: HttpExceptionFactory = DefaultHttpExceptio
         )
     }
 
+    // Added for GitLab's REST API
     inline fun <reified T> put(url: String, body: HttpRequest.BodyPublisher, headers: Map<String, String>): T {
         return request(
             HttpRequest.newBuilder()

--- a/src/main/kotlin/me/modmuss50/mpp/HttpUtils.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/HttpUtils.kt
@@ -50,7 +50,7 @@ class HttpUtils(val exceptionFactory: HttpExceptionFactory = DefaultHttpExceptio
             HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .PUT(body),
-            headers
+            headers,
         )
     }
 

--- a/src/main/kotlin/me/modmuss50/mpp/HttpUtils.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/HttpUtils.kt
@@ -44,6 +44,15 @@ class HttpUtils(val exceptionFactory: HttpExceptionFactory = DefaultHttpExceptio
         )
     }
 
+    inline fun <reified T> put(url: String, body: HttpRequest.BodyPublisher, headers: Map<String, String>): T {
+        return request(
+            HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .PUT(body),
+            headers
+        )
+    }
+
     inline fun <reified T> request(requestBuilder: HttpRequest.Builder, headers: Map<String, String>): T {
         requestBuilder.header("User-Agent", userAgent)
 

--- a/src/main/kotlin/me/modmuss50/mpp/HttpUtils.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/HttpUtils.kt
@@ -71,7 +71,7 @@ class HttpUtils(val exceptionFactory: HttpExceptionFactory = DefaultHttpExceptio
         var body = response.body()
 
         if (body.isBlank()) {
-            // Bit of a hack, but handle empty body's as an empty string.
+            // A bit of a hack, but handle empty body's as an empty string.
             body = "\"\""
         }
 

--- a/src/main/kotlin/me/modmuss50/mpp/ModPublishExtension.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/ModPublishExtension.kt
@@ -10,6 +10,7 @@ import me.modmuss50.mpp.platforms.gitea.GiteaOptions
 import me.modmuss50.mpp.platforms.gitea.GiteaOptions.HostType
 import me.modmuss50.mpp.platforms.github.Github
 import me.modmuss50.mpp.platforms.github.GithubOptions
+import me.modmuss50.mpp.platforms.gitlab.Gitlab
 import me.modmuss50.mpp.platforms.modrinth.Modrinth
 import me.modmuss50.mpp.platforms.modrinth.ModrinthOptions
 import org.gradle.api.Action
@@ -95,7 +96,7 @@ abstract class ModPublishExtension(val project: Project) : PublishOptions {
         }
     }
 
-    // Modirth
+    // Modrinth
 
     fun modrinth(@DelegatesTo(value = Modrinth::class) closure: Closure<*>): NamedDomainObjectProvider<Modrinth> {
         return modrinth {
@@ -201,6 +202,28 @@ abstract class ModPublishExtension(val project: Project) : PublishOptions {
             it.from(this)
             action.execute(it)
         }
+    }
+
+    // GitLab
+
+    fun gitlab(@DelegatesTo(value = Gitlab::class) closure: Closure<*>): NamedDomainObjectProvider<Gitlab> {
+        return gitlab("gitlab") {
+            project.configure(it, closure)
+        }
+    }
+
+    fun gitlab(action: Action<Gitlab>): NamedDomainObjectProvider<Gitlab> {
+        return gitlab("gitlab", action)
+    }
+
+    fun gitlab(name: String, @DelegatesTo(value = Gitlab::class) closure: Closure<*>): NamedDomainObjectProvider<Gitlab> {
+        return gitlab(name) {
+            project.configure(it, closure)
+        }
+    }
+
+    fun gitlab(name: String, action: Action<Gitlab>): NamedDomainObjectProvider<Gitlab> {
+        return platforms.maybeRegister(name, action)
     }
 
     // Forgejo

--- a/src/main/kotlin/me/modmuss50/mpp/MppPlugin.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/MppPlugin.kt
@@ -3,6 +3,7 @@ package me.modmuss50.mpp
 import me.modmuss50.mpp.platforms.curseforge.Curseforge
 import me.modmuss50.mpp.platforms.gitea.Gitea
 import me.modmuss50.mpp.platforms.github.Github
+import me.modmuss50.mpp.platforms.gitlab.Gitlab
 import me.modmuss50.mpp.platforms.modrinth.Modrinth
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -25,6 +26,9 @@ class MppPlugin : Plugin<Project> {
         }
         extension.platforms.registerFactory(Gitea::class.java) {
             project.objects.newInstance(Gitea::class.java, it)
+        }
+        extension.platforms.registerFactory(Gitlab::class.java) {
+            project.objects.newInstance(Gitlab::class.java, it)
         }
 
         val publishModsTask = project.tasks.register("publishMods") {

--- a/src/main/kotlin/me/modmuss50/mpp/PlatformInternal.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/PlatformInternal.kt
@@ -118,6 +118,24 @@ data class GiteaPublishResult(
         get() = url
 }
 
+@Serializable
+@SerialName("gitlab")
+data class GitlabPublishResult(
+    val projectId: Long,
+    val tagName: String,
+    val url: String,
+    override val title: String,
+) : PublishResult() {
+    override val type: String
+        get() = "gitlab"
+
+    override val link: String
+        get() = url
+
+    override val brandColor: Int
+        get() = 0xFC6D26
+}
+
 @ApiStatus.Internal
 class PublishContext(private val queue: WorkQueue, private val result: RegularFile) {
     fun <T : PublishWorkParameters> submit(workActionClass: KClass<out PublishWorkAction<T>>, parameterAction: Action<in T>) {

--- a/src/main/kotlin/me/modmuss50/mpp/PublishModTask.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/PublishModTask.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import me.modmuss50.mpp.platforms.gitea.GiteaOptions
 import me.modmuss50.mpp.platforms.github.GithubOptions
+import me.modmuss50.mpp.platforms.gitlab.GitlabOptions
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -95,6 +96,13 @@ abstract class PublishModTask @Inject constructor(@Nested val platform: Platform
 
         // Repeat the hack for Gitea.
         if (platform is GiteaOptions) {
+            if (!platform.file.isPresent && platform.allowEmptyFiles.get()) {
+                return
+            }
+        }
+
+        // And GitLab...
+        if (platform is GitlabOptions) {
             if (!platform.file.isPresent && platform.allowEmptyFiles.get()) {
                 return
             }

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/Gitlab.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/Gitlab.kt
@@ -59,7 +59,7 @@ interface GitlabOptions : PlatformOptions, PlatformOptionsInternal<GitlabOptions
     }
 
     fun from(
-        other: GitlabOptions
+        other: GitlabOptions,
     ) {
         super.from(other)
         projectId.convention(other.projectId)
@@ -71,14 +71,14 @@ interface GitlabOptions : PlatformOptions, PlatformOptionsInternal<GitlabOptions
     }
 
     fun from(
-        other: Provider<GitlabOptions>
+        other: Provider<GitlabOptions>,
     ) {
         from(other.get())
     }
 
     fun from(
         other: Provider<GitlabOptions>,
-        publishOptions: Provider<PublishOptions>
+        publishOptions: Provider<PublishOptions>,
     ) {
         from(other)
         from(publishOptions.get())
@@ -88,7 +88,7 @@ interface GitlabOptions : PlatformOptions, PlatformOptionsInternal<GitlabOptions
      * Publish to an existing release, created by another task.
      */
     fun parent(
-        task: TaskProvider<Task>
+        task: TaskProvider<Task>,
     ) {
         val publishTask = task.map { it as PublishModTask }
         releaseResult.set(publishTask.flatMap { it.result })
@@ -113,7 +113,7 @@ interface GitlabOptions : PlatformOptions, PlatformOptionsInternal<GitlabOptions
 
 abstract class Gitlab @Inject constructor(name: String) : Platform(name), GitlabOptions {
     override fun publish(
-        context: PublishContext
+        context: PublishContext,
     ) {
         val files = additionalFiles.files.toMutableList()
         if (file.isPresent) files.add(file.get().asFile)
@@ -145,7 +145,7 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
             with(parameters) {
                 val api = GitlabApi(
                     accessToken = accessToken.get(),
-                    apiEndpoint = apiEndpoint.orNull ?: "https://gitlab.com/api/v4"
+                    apiEndpoint = apiEndpoint.orNull ?: "https://gitlab.com/api/v4",
                 )
 
                 getOrCreateRelease(api)
@@ -166,7 +166,7 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
                 if (duplicates.isNotEmpty()) {
                     val duplicateNames = duplicates.keys.joinToString(", ")
                     throw IllegalStateException(
-                        "GitLab file names must be unique within a release, found duplicates: $duplicateNames"
+                        "GitLab file names must be unique within a release, found duplicates: $duplicateNames",
                     )
                 }
 
@@ -179,7 +179,7 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
                     projectId = projectId.get(),
                     tagName = tagName.get(),
                     url = "https://gitlab.com/projects/${projectId.get()}/releases/${tagName.get()}",
-                    title = announcementTitle.getOrElse("Download from GitLab")
+                    title = announcementTitle.getOrElse("Download from GitLab"),
                 )
             }
         }
@@ -187,17 +187,17 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
         data class ReleaseResult(val release: GitlabApi.Release, val created: Boolean)
 
         private fun getOrCreateRelease(
-            api: GitlabApi
+            api: GitlabApi,
         ): ReleaseResult {
             with(parameters) {
                 if (releaseResult.isPresent) {
                     val result = PublishResult.fromJson(
-                        releaseResult.get().asFile.readText()
+                        releaseResult.get().asFile.readText(),
                     ) as GitlabPublishResult
 
                     return ReleaseResult(
                         api.getRelease(projectId.get(), result.tagName),
-                        false
+                        false,
                     )
                 }
 
@@ -209,11 +209,10 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
                             name = displayName.get(),
                             tagName = tagName.get(),
                             description = changelog.get(),
-                            ref = commitish.get()
-                        )
+                            ref = commitish.get(),
+                        ),
                     )
                     ReleaseResult(release, true)
-
                 } catch (e: Exception) {
                     if (true == e.message?.contains("409") || true == e.message?.contains("already exists")) {
                         val existing = api.getRelease(projectId.get(), tagName.get())

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/Gitlab.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/Gitlab.kt
@@ -197,8 +197,8 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
                     projectId.get(),
                     tagName.get(),
                     GitlabApi.UpdateReleaseRequest(
-                        description = finalDescription
-                    )
+                        description = finalDescription,
+                    ),
                 )
 
                 return GitlabPublishResult(

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/Gitlab.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/Gitlab.kt
@@ -102,12 +102,13 @@ interface GitlabOptions : PlatformOptions, PlatformOptionsInternal<GitlabOptions
         commitish.finalizeValue()
         tagName.set(options.flatMap { it.tagName })
         tagName.finalizeValue()
-        accessToken.set(options.flatMap { it.accessToken })
     }
 }
 
 abstract class Gitlab @Inject constructor(name: String) : Platform(name), GitlabOptions {
-    override fun publish(context: PublishContext) {
+    override fun publish(
+        context: PublishContext
+    ) {
         val files = additionalFiles.files.toMutableList()
         if (file.isPresent) files.add(file.get().asFile)
 
@@ -144,23 +145,20 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
     abstract class UploadWorkAction : PublishWorkAction<UploadParams> {
         override fun publish(): PublishResult {
             with(parameters) {
-
                 val api = GitlabApi(
                     accessToken = accessToken.get(),
                     apiEndpoint = apiEndpoint.orNull ?: "https://gitlab.com/api/v4"
                 )
 
-                val (_) = getOrCreateRelease(api)
+                val (_, _) = getOrCreateRelease(api)
 
                 val files = additionalFiles.files.toMutableList()
                 if (file.isPresent) files.add(file.get().asFile)
 
                 val duplicates = files.groupingBy { it.name }.eachCount().filter { it.value > 1 }
                 if (duplicates.isNotEmpty()) {
-                    throw IllegalStateException(
-                        "GitLab file names must be unique within a release: " +
-                                duplicates.keys.joinToString(", ")
-                    )
+                    val duplicateNames = duplicates.keys.joinToString(", ")
+                    throw IllegalStateException("GitLab file names must be unique within a release, found duplicates: $duplicateNames")
                 }
 
                 for (f in files) {
@@ -171,7 +169,7 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
                 return GitlabPublishResult(
                     projectId = projectId.get(),
                     tagName = tagName.get(),
-                    url = "$apiEndpoint/projects/$projectId/releases",
+                    url = "https://gitlab.com/projects/$projectId/releases/$tagName",
                     title = announcementTitle.getOrElse("Download from GitLab")
                 )
             }
@@ -179,9 +177,10 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
 
         data class ReleaseResult(val release: GitlabApi.Release, val created: Boolean)
 
-        private fun getOrCreateRelease(api: GitlabApi): ReleaseResult {
+        private fun getOrCreateRelease(
+            api: GitlabApi
+        ): ReleaseResult {
             with(parameters) {
-
                 if (releaseResult.isPresent) {
                     val result = PublishResult.fromJson(
                         releaseResult.get().asFile.readText()
@@ -193,17 +192,29 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
                     )
                 }
 
-                val release = api.createRelease(
-                    projectId.get(),
-                    GitlabApi.CreateReleaseRequest(
-                        name = displayName.get(),
-                        tagName = tagName.get(),
-                        description = changelog.get(),
-                        ref = commitish.get()
+                return try {
+                    val release = api.createRelease(
+                        projectId.get(),
+                        GitlabApi.CreateReleaseRequest(
+                            name = displayName.get(),
+                            tagName = tagName.get(),
+                            description = changelog.get(),
+                            ref = commitish.get()
+                        )
                     )
-                )
 
-                return ReleaseResult(release, true)
+                    ReleaseResult(release, true)
+
+                } catch (e: Exception) {
+                    if (e.message?.contains("409") == true ||
+                        e.message?.contains("already exists") == true
+                    ) {
+                        val existing = api.getRelease(projectId.get(), tagName.get())
+                        ReleaseResult(existing, false)
+                    } else {
+                        throw e
+                    }
+                }
             }
         }
     }

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/Gitlab.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/Gitlab.kt
@@ -29,6 +29,9 @@ interface GitlabOptions : PlatformOptions, PlatformOptionsInternal<GitlabOptions
     @get:Optional
     override val file: RegularFileProperty
 
+    /**
+     * GitLab uses project IDs as opposed to repository links.
+     */
     @get:Input
     val projectId: Property<Long>
 
@@ -81,6 +84,9 @@ interface GitlabOptions : PlatformOptions, PlatformOptionsInternal<GitlabOptions
         from(publishOptions.get())
     }
 
+    /**
+     * Publish to an existing release, created by another task.
+     */
     fun parent(
         task: TaskProvider<Task>
     ) {
@@ -116,14 +122,6 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
             throw IllegalStateException("No files to upload to GitLab.")
         }
 
-        val duplicates = files.groupingBy { it.name }.eachCount().filter { it.value > 1 }
-        if (duplicates.isNotEmpty()) {
-            val duplicateNames = duplicates.keys.joinToString(", ")
-            throw IllegalStateException(
-                "GitLab file names must be unique within a release, found duplicates: $duplicateNames"
-            )
-        }
-
         context.submit(UploadWorkAction::class) {
             it.from(this)
         }
@@ -150,15 +148,26 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
                     apiEndpoint = apiEndpoint.orNull ?: "https://gitlab.com/api/v4"
                 )
 
-                val (_, _) = getOrCreateRelease(api)
+                getOrCreateRelease(api)
 
                 val files = additionalFiles.files.toMutableList()
-                if (file.isPresent) files.add(file.get().asFile)
+                if (file.isPresent) {
+                    files.add(file.get().asFile)
+                }
 
-                val duplicates = files.groupingBy { it.name }.eachCount().filter { it.value > 1 }
+                if (files.isEmpty() && !allowEmptyFiles.get()) {
+                    throw IllegalStateException("No files to upload to GitLab.")
+                }
+
+                val duplicates = files.groupingBy { it.name }
+                    .eachCount()
+                    .filter { it.value > 1 }
+
                 if (duplicates.isNotEmpty()) {
                     val duplicateNames = duplicates.keys.joinToString(", ")
-                    throw IllegalStateException("GitLab file names must be unique within a release, found duplicates: $duplicateNames")
+                    throw IllegalStateException(
+                        "GitLab file names must be unique within a release, found duplicates: $duplicateNames"
+                    )
                 }
 
                 for (f in files) {
@@ -169,7 +178,7 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
                 return GitlabPublishResult(
                     projectId = projectId.get(),
                     tagName = tagName.get(),
-                    url = "https://gitlab.com/projects/$projectId/releases/$tagName",
+                    url = "https://gitlab.com/projects/${projectId.get()}/releases/${tagName.get()}",
                     title = announcementTitle.getOrElse("Download from GitLab")
                 )
             }
@@ -192,6 +201,7 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
                     )
                 }
 
+                // This is a little more complicated than GitHub due to how GitLab treats tags as unique per release
                 return try {
                     val release = api.createRelease(
                         projectId.get(),
@@ -202,13 +212,10 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
                             ref = commitish.get()
                         )
                     )
-
                     ReleaseResult(release, true)
 
                 } catch (e: Exception) {
-                    if (e.message?.contains("409") == true ||
-                        e.message?.contains("already exists") == true
-                    ) {
+                    if (true == e.message?.contains("409") || true == e.message?.contains("already exists")) {
                         val existing = api.getRelease(projectId.get(), tagName.get())
                         ReleaseResult(existing, false)
                     } else {

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/Gitlab.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/Gitlab.kt
@@ -1,0 +1,210 @@
+package me.modmuss50.mpp.platforms.gitlab
+
+import me.modmuss50.mpp.GitlabPublishResult
+import me.modmuss50.mpp.Platform
+import me.modmuss50.mpp.PlatformOptions
+import me.modmuss50.mpp.PlatformOptionsInternal
+import me.modmuss50.mpp.PublishContext
+import me.modmuss50.mpp.PublishModTask
+import me.modmuss50.mpp.PublishOptions
+import me.modmuss50.mpp.PublishResult
+import me.modmuss50.mpp.PublishWorkAction
+import me.modmuss50.mpp.PublishWorkParameters
+import org.gradle.api.Task
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.logging.Logger
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.annotations.ApiStatus.Internal
+import javax.inject.Inject
+import kotlin.random.Random
+
+interface GitlabOptions : PlatformOptions, PlatformOptionsInternal<GitlabOptions> {
+
+    @get:InputFile
+    @get:Optional
+    override val file: RegularFileProperty
+
+    @get:Input
+    val projectId: Property<Long>
+
+    @get:Input
+    val tagName: Property<String>
+
+    @get:Input
+    val commitish: Property<String>
+
+    @get:Input
+    @get:Optional
+    val apiEndpoint: Property<String>
+
+    @get:Input
+    val allowEmptyFiles: Property<Boolean>
+
+    @get:InputFile
+    @get:Optional
+    @get:Internal
+    val releaseResult: RegularFileProperty
+
+    override fun setInternalDefaults() {
+        tagName.convention(version)
+        allowEmptyFiles.convention(false)
+    }
+
+    fun from(
+        other: GitlabOptions
+    ) {
+        super.from(other)
+        projectId.convention(other.projectId)
+        tagName.convention(other.tagName)
+        commitish.convention(other.commitish)
+        apiEndpoint.convention(other.apiEndpoint)
+        allowEmptyFiles.convention(other.allowEmptyFiles)
+        releaseResult.convention(other.releaseResult)
+    }
+
+    fun from(
+        other: Provider<GitlabOptions>
+    ) {
+        from(other.get())
+    }
+
+    fun from(
+        other: Provider<GitlabOptions>,
+        publishOptions: Provider<PublishOptions>
+    ) {
+        from(other)
+        from(publishOptions.get())
+    }
+
+    fun parent(
+        task: TaskProvider<Task>
+    ) {
+        val publishTask = task.map { it as PublishModTask }
+        releaseResult.set(publishTask.flatMap { it.result })
+
+        val options = publishTask.map { it.platform as GitlabOptions }
+        version.set(options.flatMap { it.version })
+        version.finalizeValue()
+        changelog.set(options.flatMap { it.changelog })
+        changelog.finalizeValue()
+        type.set(options.flatMap { it.type })
+        type.finalizeValue()
+        displayName.set(options.flatMap { it.displayName })
+        displayName.finalizeValue()
+        projectId.set(options.flatMap { it.projectId })
+        projectId.finalizeValue()
+        commitish.set(options.flatMap { it.commitish })
+        commitish.finalizeValue()
+        tagName.set(options.flatMap { it.tagName })
+        tagName.finalizeValue()
+        accessToken.set(options.flatMap { it.accessToken })
+    }
+}
+
+abstract class Gitlab @Inject constructor(name: String) : Platform(name), GitlabOptions {
+    override fun publish(context: PublishContext) {
+        val files = additionalFiles.files.toMutableList()
+        if (file.isPresent) files.add(file.get().asFile)
+
+        if (files.isEmpty() && !allowEmptyFiles.get()) {
+            throw IllegalStateException("No files to upload to GitLab.")
+        }
+
+        val duplicates = files.groupingBy { it.name }.eachCount().filter { it.value > 1 }
+        if (duplicates.isNotEmpty()) {
+            val duplicateNames = duplicates.keys.joinToString(", ")
+            throw IllegalStateException(
+                "GitLab file names must be unique within a release, found duplicates: $duplicateNames"
+            )
+        }
+
+        context.submit(UploadWorkAction::class) {
+            it.from(this)
+        }
+    }
+
+    override fun dryRunPublishResult(): PublishResult {
+        return GitlabPublishResult(
+            projectId = projectId.get(),
+            tagName = tagName.get(),
+            url = "https://gitlab.com/dry-run?random=${Random.nextInt(0, 1000000)}",
+            title = announcementTitle.getOrElse("Download from GitLab"),
+        )
+    }
+
+    override fun printDryRunInfo(logger: Logger) {}
+
+    interface UploadParams : PublishWorkParameters, GitlabOptions
+
+    abstract class UploadWorkAction : PublishWorkAction<UploadParams> {
+        override fun publish(): PublishResult {
+            with(parameters) {
+
+                val api = GitlabApi(
+                    accessToken = accessToken.get(),
+                    apiEndpoint = apiEndpoint.orNull ?: "https://gitlab.com/api/v4"
+                )
+
+                val (_) = getOrCreateRelease(api)
+
+                val files = additionalFiles.files.toMutableList()
+                if (file.isPresent) files.add(file.get().asFile)
+
+                val duplicates = files.groupingBy { it.name }.eachCount().filter { it.value > 1 }
+                if (duplicates.isNotEmpty()) {
+                    throw IllegalStateException(
+                        "GitLab file names must be unique within a release: " +
+                                duplicates.keys.joinToString(", ")
+                    )
+                }
+
+                for (f in files) {
+                    val uploaded = api.uploadAsset(projectId.get(), f)
+                    api.addAssetToRelease(projectId.get(), tagName.get(), uploaded)
+                }
+
+                return GitlabPublishResult(
+                    projectId = projectId.get(),
+                    tagName = tagName.get(),
+                    url = "$apiEndpoint/projects/$projectId/releases",
+                    title = announcementTitle.getOrElse("Download from GitLab")
+                )
+            }
+        }
+
+        data class ReleaseResult(val release: GitlabApi.Release, val created: Boolean)
+
+        private fun getOrCreateRelease(api: GitlabApi): ReleaseResult {
+            with(parameters) {
+
+                if (releaseResult.isPresent) {
+                    val result = PublishResult.fromJson(
+                        releaseResult.get().asFile.readText()
+                    ) as GitlabPublishResult
+
+                    return ReleaseResult(
+                        api.getRelease(projectId.get(), result.tagName),
+                        false
+                    )
+                }
+
+                val release = api.createRelease(
+                    projectId.get(),
+                    GitlabApi.CreateReleaseRequest(
+                        name = displayName.get(),
+                        tagName = tagName.get(),
+                        description = changelog.get(),
+                        ref = commitish.get()
+                    )
+                )
+
+                return ReleaseResult(release, true)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/Gitlab.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/Gitlab.kt
@@ -1,6 +1,7 @@
 package me.modmuss50.mpp.platforms.gitlab
 
 import me.modmuss50.mpp.GitlabPublishResult
+import me.modmuss50.mpp.HttpUtils
 import me.modmuss50.mpp.Platform
 import me.modmuss50.mpp.PlatformOptions
 import me.modmuss50.mpp.PlatformOptionsInternal
@@ -148,7 +149,7 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
                     apiEndpoint = apiEndpoint.orNull ?: "https://gitlab.com/api/v4",
                 )
 
-                getOrCreateRelease(api)
+                val releaseResult = getOrCreateRelease(api)
 
                 val files = additionalFiles.files.toMutableList()
                 if (file.isPresent) {
@@ -170,10 +171,35 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
                     )
                 }
 
-                for (f in files) {
-                    val uploaded = api.uploadAsset(projectId.get(), f)
-                    api.addAssetToRelease(projectId.get(), tagName.get(), uploaded)
+                val uploadedAssets = files.map { file ->
+                    api.uploadAsset(projectId.get(), file)
                 }
+
+                val baseRelease = if (releaseResult.created) {
+                    releaseResult.release
+                } else {
+                    api.getRelease(projectId.get(), tagName.get())
+                }
+
+                val finalDescription = buildString {
+                    append(baseRelease.description)
+
+                    if (!baseRelease.description.endsWith("\n")) {
+                        append("\n")
+                    }
+
+                    uploadedAssets.forEach { asset ->
+                        append("[${asset.name}](${asset.url})\n")
+                    }
+                }
+
+                api.updateRelease(
+                    projectId.get(),
+                    tagName.get(),
+                    GitlabApi.UpdateReleaseRequest(
+                        description = finalDescription
+                    )
+                )
 
                 return GitlabPublishResult(
                     projectId = projectId.get(),
@@ -213,8 +239,8 @@ abstract class Gitlab @Inject constructor(name: String) : Platform(name), Gitlab
                         ),
                     )
                     ReleaseResult(release, true)
-                } catch (e: Exception) {
-                    if (true == e.message?.contains("409") || true == e.message?.contains("already exists")) {
+                } catch (e: HttpUtils.HttpException) {
+                    if (e.response.statusCode() == 409) {
                         val existing = api.getRelease(projectId.get(), tagName.get())
                         ReleaseResult(existing, false)
                     } else {

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/GitlabApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/GitlabApi.kt
@@ -10,7 +10,7 @@ import java.net.http.HttpRequest
 
 class GitlabApi(
     private val accessToken: String,
-    private val apiEndpoint: String = "https://gitlab.com/api/v4"
+    private val apiEndpoint: String = "https://gitlab.com/api/v4",
 ) {
     private val httpUtils = HttpUtils()
 
@@ -20,12 +20,12 @@ class GitlabApi(
         val tagName: String,
         val name: String,
         val description: String,
-        val assets: Assets? = null
+        val assets: Assets? = null,
     )
 
     @Serializable
     data class Assets(
-        val links: List<AssetLink> = emptyList()
+        val links: List<AssetLink> = emptyList(),
     )
 
     @Serializable
@@ -33,7 +33,7 @@ class GitlabApi(
         val name: String,
         val url: String,
         @SerialName("link_type")
-        val linkType: String
+        val linkType: String,
     )
 
     @Serializable
@@ -42,20 +42,20 @@ class GitlabApi(
         @SerialName("tag_name")
         val tagName: String,
         val description: String,
-        val ref: String
+        val ref: String,
     )
 
     @Serializable
     data class UpdateReleaseRequest(
         val name: String? = null,
-        val description: String? = null
+        val description: String? = null,
     )
 
     @Serializable
     data class UploadResponse(
         val id: Long,
         val alt: String,
-        val url: String
+        val url: String,
     )
 
     private val headers: Map<String, String>
@@ -63,7 +63,7 @@ class GitlabApi(
 
     fun createRelease(
         projectId: Long,
-        request: CreateReleaseRequest
+        request: CreateReleaseRequest,
     ): Release {
         val url = "$apiEndpoint/projects/$projectId/releases"
         val body = HttpRequest.BodyPublishers.ofString(httpUtils.json.encodeToString(request))
@@ -73,7 +73,7 @@ class GitlabApi(
 
     fun getRelease(
         projectId: Long,
-        tagName: String
+        tagName: String,
     ): Release {
         val url = "$apiEndpoint/projects/$projectId/releases/$tagName"
         return httpUtils.get(url, headers)
@@ -82,7 +82,7 @@ class GitlabApi(
     fun updateRelease(
         projectId: Long,
         tagName: String,
-        request: UpdateReleaseRequest
+        request: UpdateReleaseRequest,
     ): Release {
         val url = "$apiEndpoint/projects/$projectId/releases/$tagName"
         val body = HttpRequest.BodyPublishers.ofString(httpUtils.json.encodeToString(request))
@@ -92,7 +92,7 @@ class GitlabApi(
 
     fun uploadAsset(
         projectId: Long,
-        file: File
+        file: File,
     ): AssetLink {
         val url = "$apiEndpoint/projects/$projectId/uploads"
         val builder = MultipartBodyBuilder().addFormDataPart("file", file.name, file)
@@ -103,7 +103,7 @@ class GitlabApi(
         return AssetLink(
             name = file.name,
             url = response.url,
-            linkType = "other"
+            linkType = "other",
         )
     }
 
@@ -113,7 +113,7 @@ class GitlabApi(
     fun addAssetToRelease(
         projectId: Long,
         tagName: String,
-        asset: AssetLink
+        asset: AssetLink,
     ) {
         val release = getRelease(projectId, tagName)
         val newDescription = buildString {

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/GitlabApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/GitlabApi.kt
@@ -7,22 +7,12 @@ import me.modmuss50.mpp.HttpUtils
 import me.modmuss50.mpp.MultipartBodyBuilder
 import java.io.File
 import java.net.http.HttpRequest
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 
 class GitlabApi(
     private val accessToken: String,
     private val apiEndpoint: String = "https://gitlab.com/api/v4"
 ) {
     private val httpUtils = HttpUtils()
-
-    @Serializable
-    data class Repository(
-        val id: Long,
-        val name: String,
-        @SerialName("path_with_namespace")
-        val pathWithNamespace: String,
-    )
 
     @Serializable
     data class Release(
@@ -71,15 +61,6 @@ class GitlabApi(
     private val headers: Map<String, String>
         get() = mapOf("PRIVATE-TOKEN" to accessToken)
 
-    private fun String.encodeUrl(): String = URLEncoder.encode(this, StandardCharsets.UTF_8)
-
-    fun getRepository(
-        projectPath: String
-    ): Repository {
-        val url = "$apiEndpoint/projects/${projectPath.encodeUrl()}"
-        return httpUtils.get(url, headers)
-    }
-
     fun createRelease(
         projectId: Long,
         request: CreateReleaseRequest
@@ -126,6 +107,9 @@ class GitlabApi(
         )
     }
 
+    /**
+     * Needed to update existing releases through the GitLab tag system.
+     */
     fun addAssetToRelease(
         projectId: Long,
         tagName: String,

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/GitlabApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/GitlabApi.kt
@@ -3,6 +3,7 @@ package me.modmuss50.mpp.platforms.gitlab
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import me.modmuss50.mpp.HttpUtils
 import me.modmuss50.mpp.MultipartBodyBuilder
 import java.io.File
@@ -13,6 +14,12 @@ class GitlabApi(
     private val apiEndpoint: String = "https://gitlab.com/api/v4",
 ) {
     private val httpUtils = HttpUtils()
+
+    @OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+    private val gitlabJson = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
 
     @Serializable
     data class Release(
@@ -66,7 +73,7 @@ class GitlabApi(
         request: CreateReleaseRequest,
     ): Release {
         val url = "$apiEndpoint/projects/$projectId/releases"
-        val body = HttpRequest.BodyPublishers.ofString(httpUtils.json.encodeToString(request))
+        val body = HttpRequest.BodyPublishers.ofString(gitlabJson.encodeToString(request))
         val headersWithContentType = headers + ("Content-Type" to "application/json")
         return httpUtils.post(url, body, headersWithContentType)
     }
@@ -75,7 +82,8 @@ class GitlabApi(
         projectId: Long,
         tagName: String,
     ): Release {
-        val url = "$apiEndpoint/projects/$projectId/releases/$tagName"
+        val encodedTag = java.net.URLEncoder.encode(tagName, Charsets.UTF_8)
+        val url = "$apiEndpoint/projects/$projectId/releases/$encodedTag"
         return httpUtils.get(url, headers)
     }
 
@@ -84,8 +92,9 @@ class GitlabApi(
         tagName: String,
         request: UpdateReleaseRequest,
     ): Release {
-        val url = "$apiEndpoint/projects/$projectId/releases/$tagName"
-        val body = HttpRequest.BodyPublishers.ofString(httpUtils.json.encodeToString(request))
+        val encodedTag = java.net.URLEncoder.encode(tagName, Charsets.UTF_8)
+        val url = "$apiEndpoint/projects/$projectId/releases/$encodedTag"
+        val body = HttpRequest.BodyPublishers.ofString(gitlabJson.encodeToString(request))
         val headersWithContentType = headers + ("Content-Type" to "application/json")
         return httpUtils.put(url, body, headersWithContentType)
     }
@@ -105,22 +114,5 @@ class GitlabApi(
             url = response.url,
             linkType = "other",
         )
-    }
-
-    /**
-     * Needed to update existing releases through the GitLab tag system.
-     */
-    fun addAssetToRelease(
-        projectId: Long,
-        tagName: String,
-        asset: AssetLink,
-    ) {
-        val release = getRelease(projectId, tagName)
-        val newDescription = buildString {
-            append(release.description)
-            if (!release.description.endsWith("\n")) append("\n")
-            append("[${asset.name}](${asset.url})")
-        }
-        updateRelease(projectId, tagName, UpdateReleaseRequest(description = newDescription))
     }
 }

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/GitlabApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/GitlabApi.kt
@@ -1,0 +1,142 @@
+package me.modmuss50.mpp.platforms.gitlab
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import me.modmuss50.mpp.HttpUtils
+import me.modmuss50.mpp.MultipartBodyBuilder
+import java.io.File
+import java.net.http.HttpRequest
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+class GitlabApi(
+    private val accessToken: String,
+    private val apiEndpoint: String = "https://gitlab.com/api/v4"
+) {
+    private val httpUtils = HttpUtils()
+
+    @Serializable
+    data class Repository(
+        val id: Long,
+        val name: String,
+        @SerialName("path_with_namespace")
+        val pathWithNamespace: String,
+    )
+
+    @Serializable
+    data class Release(
+        @SerialName("tag_name")
+        val tagName: String,
+        val name: String,
+        val description: String,
+        val assets: Assets? = null
+    )
+
+    @Serializable
+    data class Assets(
+        val links: List<AssetLink> = emptyList()
+    )
+
+    @Serializable
+    data class AssetLink(
+        val name: String,
+        val url: String,
+        @SerialName("link_type")
+        val linkType: String
+    )
+
+    @Serializable
+    data class CreateReleaseRequest(
+        val name: String,
+        @SerialName("tag_name")
+        val tagName: String,
+        val description: String,
+        val ref: String
+    )
+
+    @Serializable
+    data class UpdateReleaseRequest(
+        val name: String? = null,
+        val description: String? = null
+    )
+
+    @Serializable
+    data class UploadResponse(
+        val id: Long,
+        val alt: String,
+        val url: String
+    )
+
+    private val headers: Map<String, String>
+        get() = mapOf("PRIVATE-TOKEN" to accessToken)
+
+    private fun String.encodeUrl(): String = URLEncoder.encode(this, StandardCharsets.UTF_8)
+
+    fun getRepository(
+        projectPath: String
+    ): Repository {
+        val url = "$apiEndpoint/projects/${projectPath.encodeUrl()}"
+        return httpUtils.get(url, headers)
+    }
+
+    fun createRelease(
+        projectId: Long,
+        request: CreateReleaseRequest
+    ): Release {
+        val url = "$apiEndpoint/projects/$projectId/releases"
+        val body = HttpRequest.BodyPublishers.ofString(httpUtils.json.encodeToString(request))
+        val headersWithContentType = headers + ("Content-Type" to "application/json")
+        return httpUtils.post(url, body, headersWithContentType)
+    }
+
+    fun getRelease(
+        projectId: Long,
+        tagName: String
+    ): Release {
+        val url = "$apiEndpoint/projects/$projectId/releases/$tagName"
+        return httpUtils.get(url, headers)
+    }
+
+    fun updateRelease(
+        projectId: Long,
+        tagName: String,
+        request: UpdateReleaseRequest
+    ): Release {
+        val url = "$apiEndpoint/projects/$projectId/releases/$tagName"
+        val body = HttpRequest.BodyPublishers.ofString(httpUtils.json.encodeToString(request))
+        val headersWithContentType = headers + ("Content-Type" to "application/json")
+        return httpUtils.put(url, body, headersWithContentType)
+    }
+
+    fun uploadAsset(
+        projectId: Long,
+        file: File
+    ): AssetLink {
+        val url = "$apiEndpoint/projects/$projectId/uploads"
+        val builder = MultipartBodyBuilder().addFormDataPart("file", file.name, file)
+        val bodyPublisher = builder.build()
+        val headersWithContentType = headers + ("Content-Type" to builder.getContentType())
+        val response: UploadResponse = httpUtils.post(url, bodyPublisher, headersWithContentType)
+
+        return AssetLink(
+            name = file.name,
+            url = response.url,
+            linkType = "other"
+        )
+    }
+
+    fun addAssetToRelease(
+        projectId: Long,
+        tagName: String,
+        asset: AssetLink
+    ) {
+        val release = getRelease(projectId, tagName)
+        val newDescription = buildString {
+            append(release.description)
+            if (!release.description.endsWith("\n")) append("\n")
+            append("[${asset.name}](${asset.url})")
+        }
+        updateRelease(projectId, tagName, UpdateReleaseRequest(description = newDescription))
+    }
+}

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitlab/GitlabTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitlab/GitlabTest.kt
@@ -28,7 +28,7 @@ class GitlabTest : IntegrationTest {
                             tagName = "release-1.0.0"
                         }
                     }
-                """.trimIndent()
+                """.trimIndent(),
             )
             .run("publishGitlab")
         server.close()
@@ -56,7 +56,7 @@ class GitlabTest : IntegrationTest {
                             additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
                         }
                     }
-                """.trimIndent()
+                """.trimIndent(),
             )
             .run("publishGitlab")
         server.close()
@@ -89,7 +89,7 @@ class GitlabTest : IntegrationTest {
                             parent(tasks.named("publishGitlab"))
                         }
                     }
-                """.trimIndent()
+                """.trimIndent(),
             )
             .run("publishGitlabOther")
         server.close()
@@ -117,7 +117,7 @@ class GitlabTest : IntegrationTest {
                             allowEmptyFiles = true
                         }
                     }
-                """.trimIndent()
+                """.trimIndent(),
             )
             .subProject(
                 "child",
@@ -130,7 +130,7 @@ class GitlabTest : IntegrationTest {
                             file = tasks.jar.flatMap { it.archiveFile }
                         }
                     }
-                """.trimIndent()
+                """.trimIndent(),
             )
             .run("publishMods")
         server.close()
@@ -160,7 +160,7 @@ class GitlabTest : IntegrationTest {
                             allowEmptyFiles = true
                         }
                     }
-                """.trimIndent()
+                """.trimIndent(),
             )
             .run("publishGitlab")
         server.close()
@@ -191,7 +191,7 @@ class GitlabTest : IntegrationTest {
                         additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
                     }
                 }
-            """.trimIndent()
+                """.trimIndent(),
             )
             .run("publishGitlab")
         server.close()

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitlab/GitlabTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitlab/GitlabTest.kt
@@ -1,0 +1,202 @@
+package me.modmuss50.mpp.test.gitlab
+
+import me.modmuss50.mpp.test.IntegrationTest
+import me.modmuss50.mpp.test.MockWebServer
+import org.gradle.testkit.runner.TaskOutcome
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class GitlabTest : IntegrationTest {
+    @Test
+    fun uploadGitlab() {
+        val server = MockWebServer(MockGitlabApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        gitlab {
+                            accessToken = "123"
+                            projectId = 1
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                            tagName = "release-1.0.0"
+                        }
+                    }
+                """.trimIndent()
+            )
+            .run("publishGitlab")
+        server.close()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitlab")!!.outcome)
+    }
+
+    @Test
+    fun noMainFile() {
+        val server = MockWebServer(MockGitlabApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                    publishMods {
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        gitlab {
+                            accessToken = "123"
+                            projectId = 1
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                            tagName = "release-1.0.0"
+                            additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
+                        }
+                    }
+                """.trimIndent()
+            )
+            .run("publishGitlab")
+        server.close()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitlab")!!.outcome)
+    }
+
+    @Test
+    fun uploadGitlabExistingRelease() {
+        val server = MockWebServer(MockGitlabApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        gitlab {
+                            accessToken = "123"
+                            projectId = 1
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                            tagName = "release-1.0.0"
+                        }
+                        gitlab("gitlabOther") {
+                            accessToken = "123"
+                            apiEndpoint = "${server.endpoint}"
+                            parent(tasks.named("publishGitlab"))
+                        }
+                    }
+                """.trimIndent()
+            )
+            .run("publishGitlabOther")
+        server.close()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitlabOther")!!.outcome)
+    }
+
+    @Test
+    fun allowEmptyFiles() {
+        val server = MockWebServer(MockGitlabApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                    publishMods {
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        gitlab {
+                            accessToken = "123"
+                            projectId = 1
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                            tagName = "release-1.0.0"
+                            allowEmptyFiles = true
+                        }
+                    }
+                """.trimIndent()
+            )
+            .subProject(
+                "child",
+                """
+                    publishMods {
+                        gitlab {
+                            accessToken = "123"
+                            apiEndpoint = "${server.endpoint}"
+                            parent(project(":").tasks.named("publishGitlab"))
+                            file = tasks.jar.flatMap { it.archiveFile }
+                        }
+                    }
+                """.trimIndent()
+            )
+            .run("publishMods")
+        server.close()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitlab")!!.outcome)
+        assertEquals(TaskOutcome.SUCCESS, result.task(":child:publishGitlab")!!.outcome)
+    }
+
+    @Test
+    fun allowEmptyFilesDryRun() {
+        val server = MockWebServer(MockGitlabApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                    publishMods {
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        dryRun = true
+                        gitlab {
+                            accessToken = "123"
+                            projectId = 1
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                            tagName = "release-1.0.0"
+                            allowEmptyFiles = true
+                        }
+                    }
+                """.trimIndent()
+            )
+            .run("publishGitlab")
+        server.close()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitlab")!!.outcome)
+    }
+
+    @Test
+    fun failOnDuplicateNames() {
+        val server = MockWebServer(MockGitlabApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                publishMods {
+                    file = tasks.jar.flatMap { it.archiveFile }
+                    changelog = "Hello!"
+                    version = "1.0.0"
+                    type = STABLE
+
+                    gitlab {
+                        accessToken = "123"
+                        projectId = 1
+                        commitish = "main"
+                        apiEndpoint = "${server.endpoint}"
+                        tagName = "release-1.0.0"
+
+                        additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
+                    }
+                }
+            """.trimIndent()
+            )
+            .run("publishGitlab")
+        server.close()
+
+        assertEquals(TaskOutcome.FAILED, result.task(":publishGitlab")!!.outcome)
+        assertContains(result.output, "GitLab file names must be unique within a release, found duplicates: mpp-example.jar")
+    }
+}

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitlab/MockGitlabApi.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitlab/MockGitlabApi.kt
@@ -92,7 +92,9 @@ class MockGitlabApi : MockWebServer.MockApi {
         )
     }
 
-    private fun uploadAsset(context: Context) {
+    private fun uploadAsset(
+        context: Context
+    ) {
         val projectId = context.pathParam("projectId")
         val fileName = context.queryParam("name") ?: "mock-file.txt"
         context.result(

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitlab/MockGitlabApi.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitlab/MockGitlabApi.kt
@@ -100,7 +100,7 @@ class MockGitlabApi : MockWebServer.MockApi {
         context.result(
             """
         {
-          "id": "1",
+          "id": 1,
           "alt": "$fileName",
           "url": "http://localhost:${context.port()}/projects/$projectId/uploads/$fileName"
         }

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitlab/MockGitlabApi.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitlab/MockGitlabApi.kt
@@ -1,8 +1,8 @@
 package me.modmuss50.mpp.test.gitlab
 
 import io.javalin.apibuilder.ApiBuilder.get
-import io.javalin.apibuilder.ApiBuilder.post
 import io.javalin.apibuilder.ApiBuilder.path
+import io.javalin.apibuilder.ApiBuilder.post
 import io.javalin.apibuilder.ApiBuilder.put
 import io.javalin.apibuilder.EndpointGroup
 import io.javalin.http.Context
@@ -24,10 +24,10 @@ class MockGitlabApi : MockWebServer.MockApi {
                     }
                 }
             }
-    }
+        }
 
     private fun getProject(
-        context: Context
+        context: Context,
     ) {
         val id = context.pathParam("projectId")
         context.result(
@@ -37,12 +37,12 @@ class MockGitlabApi : MockWebServer.MockApi {
               "name": "mock-project",
               "path_with_namespace": "mock/namespace/mock-project"
             }
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
     private fun createRelease(
-        context: Context
+        context: Context,
     ) {
         val tagName = context.queryParam("tag_name") ?: "v1.0"
         val projectId = context.pathParam("projectId")
@@ -54,12 +54,12 @@ class MockGitlabApi : MockWebServer.MockApi {
               "description": "Mock release for project $projectId",
               "assets": { "links": [] }
             }
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
     private fun updateRelease(
-        context: Context
+        context: Context,
     ) {
         val tagName = context.pathParam("tagName")
         val projectId = context.pathParam("projectId")
@@ -71,12 +71,12 @@ class MockGitlabApi : MockWebServer.MockApi {
               "description": "Updated mock release for project $projectId",
               "assets": { "links": [] }
             }
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
     private fun getRelease(
-        context: Context
+        context: Context,
     ) {
         val tagName = context.pathParam("tagName")
         val projectId = context.pathParam("projectId")
@@ -88,12 +88,12 @@ class MockGitlabApi : MockWebServer.MockApi {
               "description": "Mock release for project $projectId",
               "assets": { "links": [] }
             }
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
     private fun uploadAsset(
-        context: Context
+        context: Context,
     ) {
         val projectId = context.pathParam("projectId")
         val fileName = context.queryParam("name") ?: "mock-file.txt"
@@ -104,7 +104,7 @@ class MockGitlabApi : MockWebServer.MockApi {
           "alt": "$fileName",
           "url": "http://localhost:${context.port()}/projects/$projectId/uploads/$fileName"
         }
-        """.trimIndent()
+            """.trimIndent(),
         )
     }
 }

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitlab/MockGitlabApi.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitlab/MockGitlabApi.kt
@@ -1,0 +1,108 @@
+package me.modmuss50.mpp.test.gitlab
+
+import io.javalin.apibuilder.ApiBuilder.get
+import io.javalin.apibuilder.ApiBuilder.post
+import io.javalin.apibuilder.ApiBuilder.path
+import io.javalin.apibuilder.ApiBuilder.put
+import io.javalin.apibuilder.EndpointGroup
+import io.javalin.http.Context
+import me.modmuss50.mpp.test.MockWebServer
+
+class MockGitlabApi : MockWebServer.MockApi {
+    override fun routes(): EndpointGroup =
+        EndpointGroup {
+            path("projects") {
+                path("{projectId}") {
+                    get(this::getProject)
+                    path("releases") {
+                        post(this::createRelease)
+                        get("{tagName}", this::getRelease)
+                        put("{tagName}", this::updateRelease)
+                    }
+                    path("uploads") {
+                        post(this::uploadAsset)
+                    }
+                }
+            }
+    }
+
+    private fun getProject(
+        context: Context
+    ) {
+        val id = context.pathParam("projectId")
+        context.result(
+            """
+            {
+              "id": $id,
+              "name": "mock-project",
+              "path_with_namespace": "mock/namespace/mock-project"
+            }
+            """.trimIndent()
+        )
+    }
+
+    private fun createRelease(
+        context: Context
+    ) {
+        val tagName = context.queryParam("tag_name") ?: "v1.0"
+        val projectId = context.pathParam("projectId")
+        context.result(
+            """
+            {
+              "tag_name": "$tagName",
+              "name": "Release $tagName",
+              "description": "Mock release for project $projectId",
+              "assets": { "links": [] }
+            }
+            """.trimIndent()
+        )
+    }
+
+    private fun updateRelease(
+        context: Context
+    ) {
+        val tagName = context.pathParam("tagName")
+        val projectId = context.pathParam("projectId")
+        context.result(
+            """
+            {
+              "tag_name": "$tagName",
+              "name": "Updated Release $tagName",
+              "description": "Updated mock release for project $projectId",
+              "assets": { "links": [] }
+            }
+            """.trimIndent()
+        )
+    }
+
+    private fun getRelease(
+        context: Context
+    ) {
+        val tagName = context.pathParam("tagName")
+        val projectId = context.pathParam("projectId")
+        context.result(
+            """
+            {
+              "tag_name": "$tagName",
+              "name": "Release $tagName",
+              "description": "Mock release for project $projectId",
+              "assets": { "links": [] }
+            }
+            """.trimIndent()
+        )
+    }
+
+    private fun uploadAsset(context: Context) {
+        val projectId = context.pathParam("projectId")
+        val fileName = context.queryParam("name") ?: "mock-file.txt"
+        context.result(
+            """
+        {
+          "id": "1",
+          "alt": "$fileName",
+          "url": "http://localhost:${context.port()}/projects/$projectId/uploads/$fileName"
+        }
+        """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
Added basic functionality for GitLab's REST API based on previous work done for GitHub and Gitea. Tests currently pass and files in my own test project are published properly. Current changes should be non-breaking for end users as they are mostly additional.