### PR TITLE
IMPROVEMENT: Added 'BeforeTest' and 'AfterTest' annotations to platform tests

### DIFF
--- a/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeTest.kt
@@ -4,48 +4,59 @@ import me.modmuss50.mpp.platforms.curseforge.CurseforgeApi
 import me.modmuss50.mpp.test.IntegrationTest
 import me.modmuss50.mpp.test.MockWebServer
 import org.gradle.testkit.runner.TaskOutcome
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 class CurseforgeTest : IntegrationTest {
+    private lateinit var server: MockWebServer<MockCurseforgeApi>
+
+    @BeforeTest
+    fun setup() {
+        server = MockWebServer(MockCurseforgeApi())
+    }
+
+    @AfterTest
+    fun cleanup() {
+        server.close()
+    }
+
     @Test
     fun uploadCurseforge() {
-        val server = MockWebServer(MockCurseforgeApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "<p>Hello!</p>"
-                    version = "1.0.0"
-                    type = BETA
-                    modLoaders.add("fabric")
-                    displayName = "Test Upload"
-                
-                    curseforge {
-                        accessToken = "123"
-                        projectId = "123456"
-                        minecraftVersions.add("1.20.1")
-                        javaVersions.add(JavaVersion.VERSION_17)
-                        clientRequired = true
-                        serverRequired = true
-                        changelogType = "html"
-                        
-                        requires {
-                            slug = "fabric-api"
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "<p>Hello!</p>"
+                        version = "1.0.0"
+                        type = BETA
+                        modLoaders.add("fabric")
+                        displayName = "Test Upload"
+                    
+                        curseforge {
+                            accessToken = "123"
+                            projectId = "123456"
+                            minecraftVersions.add("1.20.1")
+                            javaVersions.add(JavaVersion.VERSION_17)
+                            clientRequired = true
+                            serverRequired = true
+                            changelogType = "html"
+                            
+                            requires {
+                                slug = "fabric-api"
+                            }
+                            
+                            requires("mod-test", "mod-test-2")
+                            
+                            apiEndpoint = "${server.endpoint}"
                         }
-                        
-                        requires("mod-test", "mod-test-2")
-                        
-                        apiEndpoint = "${server.endpoint}"
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishCurseforge")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishCurseforge")
 
         val metadata = server.api.lastMetadata!!
 
@@ -65,55 +76,52 @@ class CurseforgeTest : IntegrationTest {
 
     @Test
     fun uploadCurseforgeWithOptions() {
-        val server = MockWebServer(MockCurseforgeApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                val fabricJar = tasks.register("fabricJar", Jar::class.java) {
-                    archiveClassifier = "fabric"
-                }
-                val forgeJar = tasks.register("forgeJar", Jar::class.java) {
-                    archiveClassifier = "forge"
-                }
-
-                publishMods {
-                    changelog = "Hello!"
-                    version = "1.0.0"
-                    type = BETA
-                
-                    // Common options that can be re-used between diffrent curseforge tasks
-                    val curseforgeOptions = curseforgeOptions {
-                        accessToken = "123"
-                        apiEndpoint = "${server.endpoint}"
-                        minecraftVersionRange {
-                            start = "1.19.4"
-                            end = "1.20.1"
-                        }
-                        changelogType = "text"
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    val fabricJar = tasks.register("fabricJar", Jar::class.java) {
+                        archiveClassifier = "fabric"
                     }
-                
-                    curseforge("curseforgeFabric") {
-                        from(curseforgeOptions)
-                        file = fabricJar.flatMap { it.archiveFile }
-                        projectId = "123456"
-                        modLoaders.add("fabric")
-                        requires {
-                            slug = "fabric-api"
-                        }
+                    val forgeJar = tasks.register("forgeJar", Jar::class.java) {
+                        archiveClassifier = "forge"
                     }
+
+                    publishMods {
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = BETA
                     
-                    curseforge("curseforgeForge") {
-                        from(curseforgeOptions)
-                        file = forgeJar.flatMap { it.archiveFile }
-                        projectId = "789123"
-                        modLoaders.add("forge")
+                        // Common options that can be re-used between diffrent curseforge tasks
+                        val curseforgeOptions = curseforgeOptions {
+                            accessToken = "123"
+                            apiEndpoint = "${server.endpoint}"
+                            minecraftVersionRange {
+                                start = "1.19.4"
+                                end = "1.20.1"
+                            }
+                            changelogType = "text"
+                        }
+                    
+                        curseforge("curseforgeFabric") {
+                            from(curseforgeOptions)
+                            file = fabricJar.flatMap { it.archiveFile }
+                            projectId = "123456"
+                            modLoaders.add("fabric")
+                            requires {
+                                slug = "fabric-api"
+                            }
+                        }
+                        
+                        curseforge("curseforgeForge") {
+                            from(curseforgeOptions)
+                            file = forgeJar.flatMap { it.archiveFile }
+                            projectId = "789123"
+                            modLoaders.add("forge")
+                        }
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         val metadata = server.api.lastMetadata!!
 
@@ -129,31 +137,28 @@ class CurseforgeTest : IntegrationTest {
 
     @Test
     fun uploadCurseforgeMinecraftVersionList() {
-        val server = MockWebServer(MockCurseforgeApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "<p>Hello!</p>"
-                    version = "1.0.0"
-                    type = BETA
-                    modLoaders.add("fabric")
-                    displayName = "Test Upload"
-                    
-                    curseforge {
-                        accessToken = "123"
-                        projectId = "123456"
-                        minecraftVersionList("1.19.4, 1.20, 1.20.1")
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "<p>Hello!</p>"
+                        version = "1.0.0"
+                        type = BETA
+                        modLoaders.add("fabric")
+                        displayName = "Test Upload"
                         
-                        apiEndpoint = "${server.endpoint}"
+                        curseforge {
+                            accessToken = "123"
+                            projectId = "123456"
+                            minecraftVersionList("1.19.4, 1.20, 1.20.1")
+                            
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         val metadata = server.api.lastMetadata!!
 
@@ -166,52 +171,49 @@ class CurseforgeTest : IntegrationTest {
     // Also test in groovy to ensure that the closures are working as expected
     @Test
     fun uploadCurseforgeWithOptionsGroovy() {
-        val server = MockWebServer(MockCurseforgeApi())
-
-        val result = gradleTest(groovy = true)
-            .buildScript(
-                """
-                tasks.register("fabricJar", Jar) {
-                    archiveClassifier = "fabric"
-                }
-                tasks.register("forgeJar", Jar) {
-                    archiveClassifier = "forge"
-                }
-
-                publishMods {
-                    changelog = "Hello!"
-                    version = "1.0.0"
-                    type = BETA
-                
-                    // Common options that can be re-used between diffrent curseforge tasks
-                    def curseforgeOptions = curseforgeOptions {
-                        accessToken = "123"
-                        minecraftVersions.add("1.20.1")
-                        apiEndpoint = "${server.endpoint}"
-                        changelogType = "markdown"
+        val result =
+            gradleTest(groovy = true)
+                .buildScript(
+                    """
+                    tasks.register("fabricJar", Jar) {
+                        archiveClassifier = "fabric"
                     }
-                
-                    curseforge("curseforgeFabric") {
-                        from curseforgeOptions
-                        file = fabricJar.archiveFile
-                        projectId = "123456"
-                        modLoaders.add("fabric")
-                        requires {
-                            slug = "fabric-api"
+                    tasks.register("forgeJar", Jar) {
+                        archiveClassifier = "forge"
+                    }
+
+                    publishMods {
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = BETA
+                    
+                        // Common options that can be re-used between diffrent curseforge tasks
+                        def curseforgeOptions = curseforgeOptions {
+                            accessToken = "123"
+                            minecraftVersions.add("1.20.1")
+                            apiEndpoint = "${server.endpoint}"
+                            changelogType = "markdown"
+                        }
+                    
+                        curseforge("curseforgeFabric") {
+                            from curseforgeOptions
+                            file = fabricJar.archiveFile
+                            projectId = "123456"
+                            modLoaders.add("fabric")
+                            requires {
+                                slug = "fabric-api"
+                            }
+                        }
+                        
+                        curseforge("curseforgeForge") {
+                            from curseforgeOptions
+                            file = forgeJar.archiveFile
+                            projectId = "789123"
+                            modLoaders.add("forge")
                         }
                     }
-                    
-                    curseforge("curseforgeForge") {
-                        from curseforgeOptions
-                        file = forgeJar.archiveFile
-                        projectId = "789123"
-                        modLoaders.add("forge")
-                    }
-                }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         val metadata = server.api.lastMetadata!!
 
@@ -224,64 +226,61 @@ class CurseforgeTest : IntegrationTest {
 
     @Test
     fun dryRunCurseforge() {
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "Hello!"
-                    version = "1.0.0"
-                    type = BETA
-                    modLoaders.add("fabric")
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = BETA
+                        modLoaders.add("fabric")
+                        
+                        dryRun = true
                     
-                    dryRun = true
-                
-                    curseforge {
-                        accessToken = providers.environmentVariable("TEST_TOKEN_THAT_DOES_NOT_EXISTS")
-                        projectId = "123456"
-                        minecraftVersions.add("1.20.1")
-                        requires {
-                            slug = "fabric-api"
+                        curseforge {
+                            accessToken = providers.environmentVariable("TEST_TOKEN_THAT_DOES_NOT_EXISTS")
+                            projectId = "123456"
+                            minecraftVersions.add("1.20.1")
+                            requires {
+                                slug = "fabric-api"
+                            }
                         }
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishCurseforge")
+                    """.trimIndent(),
+                ).run("publishCurseforge")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishCurseforge")!!.outcome)
     }
 
     @Test
     fun uploadCurseforgeError() {
-        val server = MockWebServer(MockCurseforgeApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "Hello!"
-                    version = "1.0.0"
-                    type = BETA
-                    modLoaders.add("fabric")
-                
-                    curseforge {
-                        accessToken = "abc"
-                        projectId = "123456"
-                        minecraftVersions.add("1.20.1")
-                        
-                        requires {
-                            slug = "fabric-api"
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = BETA
+                        modLoaders.add("fabric")
+                    
+                        curseforge {
+                            accessToken = "abc"
+                            projectId = "123456"
+                            minecraftVersions.add("1.20.1")
+                            
+                            requires {
+                                slug = "fabric-api"
+                            }
+                            
+                            apiEndpoint = "${server.endpoint}"
                         }
-                        
-                        apiEndpoint = "${server.endpoint}"
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishCurseforge")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishCurseforge")
 
         assertEquals(TaskOutcome.FAILED, result.task(":publishCurseforge")!!.outcome)
         result.output.contains("Request failed, status: 401 message: You must provide an API token using the `X-Api-Token` header")
@@ -289,30 +288,27 @@ class CurseforgeTest : IntegrationTest {
 
     @Test
     fun uploadCurseforgeNoDeps() {
-        val server = MockWebServer(MockCurseforgeApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "Hello!"
-                    version = "1.0.0"
-                    type = BETA
-                    modLoaders.add("fabric")
-                
-                    curseforge {
-                        accessToken = "123"
-                        projectId = "123456"
-                        minecraftVersions.add("1.20.1")
-                        
-                        apiEndpoint = "${server.endpoint}"
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = BETA
+                        modLoaders.add("fabric")
+                    
+                        curseforge {
+                            accessToken = "123"
+                            projectId = "123456"
+                            minecraftVersions.add("1.20.1")
+                            
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishCurseforge")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishCurseforge")
 
         val metadata = server.api.lastMetadata!!
 
@@ -324,34 +320,31 @@ class CurseforgeTest : IntegrationTest {
     // Test to ensure that a version is set
     @Test
     fun uploadCurseforgeNoVersionError() {
-        val server = MockWebServer(MockCurseforgeApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "Hello!"
-                    type = BETA
-                    modLoaders.add("fabric")
-                
-                    curseforge {
-                        accessToken = "abc"
-                        projectId = "123456"
-                        minecraftVersions.add("1.20.1")
-                        
-                        requires {
-                            slug = "fabric-api"
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        type = BETA
+                        modLoaders.add("fabric")
+                    
+                        curseforge {
+                            accessToken = "abc"
+                            projectId = "123456"
+                            minecraftVersions.add("1.20.1")
+                            
+                            requires {
+                                slug = "fabric-api"
+                            }
+                            
+                            apiEndpoint = "${server.endpoint}"
                         }
-                        
-                        apiEndpoint = "${server.endpoint}"
                     }
-                }
-                """.trimIndent(),
-            )
-            .notConfigCacheCompatible()
-            .run("publishCurseforge")
-        server.close()
+                    """.trimIndent(),
+                ).notConfigCacheCompatible()
+                .run("publishCurseforge")
 
         assertEquals(TaskOutcome.FAILED, result.task(":publishCurseforge")!!.outcome)
         result.output.contains("Gradle version is unspecified")
@@ -359,27 +352,27 @@ class CurseforgeTest : IntegrationTest {
 
     @Test
     fun validateNoDuplicateVersions() {
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "Hello!"
-                    version = "1.0.0"
-                    type = BETA
-                    modLoaders.add("fabric")
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = BETA
+                        modLoaders.add("fabric")
+                        
+                        dryRun = true
                     
-                    dryRun = true
-                
-                    curseforge {
-                        projectId = "123456"
-                        minecraftVersions.add("1.20.1")
-                        minecraftVersions.add("1.20.1")
+                        curseforge {
+                            projectId = "123456"
+                            minecraftVersions.add("1.20.1")
+                            minecraftVersions.add("1.20.1")
+                        }
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishCurseforge")
+                    """.trimIndent(),
+                ).run("publishCurseforge")
 
         assertEquals(TaskOutcome.FAILED, result.task(":publishCurseforge")!!.outcome)
         assertContains(result.output, "minecraftVersions contains duplicate values: [1.20.1]")
@@ -387,44 +380,41 @@ class CurseforgeTest : IntegrationTest {
 
     @Test
     fun additionalFiles() {
-        val server = MockWebServer(MockCurseforgeApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                val fabricJar = tasks.register("fabricJar", Jar::class.java) {
-                    archiveClassifier = "fabric"
-                }
-                val forgeJar = tasks.register("forgeJar", Jar::class.java) {
-                    archiveClassifier = "forge"
-                }
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "<p>Hello!</p>"
-                    version = "1.0.0"
-                    type = BETA
-                    modLoaders.add("fabric")
-                
-                    curseforge {
-                        accessToken = "123"
-                        projectId = "123456"
-                        minecraftVersions.add("1.20.1")
-                        
-                        additionalFile(fabricJar.flatMap { it.archiveFile }) {
-                            name = "Fabric"
-                        }
-
-                        additionalFile(forgeJar.flatMap { it.archiveFile }) {
-                            name = "Forge"
-                        }
-
-                        apiEndpoint = "${server.endpoint}"
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    val fabricJar = tasks.register("fabricJar", Jar::class.java) {
+                        archiveClassifier = "fabric"
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishCurseforge")
-        server.close()
+                    val forgeJar = tasks.register("forgeJar", Jar::class.java) {
+                        archiveClassifier = "forge"
+                    }
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "<p>Hello!</p>"
+                        version = "1.0.0"
+                        type = BETA
+                        modLoaders.add("fabric")
+                    
+                        curseforge {
+                            accessToken = "123"
+                            projectId = "123456"
+                            minecraftVersions.add("1.20.1")
+                            
+                            additionalFile(fabricJar.flatMap { it.archiveFile }) {
+                                name = "Fabric"
+                            }
+
+                            additionalFile(forgeJar.flatMap { it.archiveFile }) {
+                                name = "Forge"
+                            }
+
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                    }
+                    """.trimIndent(),
+                ).run("publishCurseforge")
 
         val metadata = server.api.allMetadata
 
@@ -436,30 +426,27 @@ class CurseforgeTest : IntegrationTest {
 
     @Test
     fun fileFromSubProject() {
-        val server = MockWebServer(MockCurseforgeApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file(project(":child"))
-                    changelog = "<p>Hello!</p>"
-                    version = "1.0.0"
-                    type = BETA
-                    modLoaders.add("fabric")
-                
-                    curseforge {
-                        accessToken = "123"
-                        projectId = "123456"
-                        minecraftVersions.add("1.20.1")
-                        apiEndpoint = "${server.endpoint}"
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file(project(":child"))
+                        changelog = "<p>Hello!</p>"
+                        version = "1.0.0"
+                        type = BETA
+                        modLoaders.add("fabric")
+                    
+                        curseforge {
+                            accessToken = "123"
+                            projectId = "123456"
+                            minecraftVersions.add("1.20.1")
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     }
-                }
-                """.trimIndent(),
-            )
-            .subProject("child")
-            .run("publishCurseforge")
-        server.close()
+                    """.trimIndent(),
+                ).subProject("child")
+                .run("publishCurseforge")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":child:jar")!!.outcome)
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishCurseforge")!!.outcome)
@@ -467,69 +454,66 @@ class CurseforgeTest : IntegrationTest {
 
     @Test
     fun invalidDependency() {
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "Hello!"
-                    version = "1.0.0"
-                    type = BETA
-                    modLoaders.add("fabric")
-                    dryRun = true
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = BETA
+                        modLoaders.add("fabric")
+                        dryRun = true
 
-                    curseforge {
-                        accessToken = providers.environmentVariable("TEST_TOKEN_THAT_DOES_NOT_EXISTS")
-                        projectId = "123456"
-                        minecraftVersions.add("1.20.1")
-                        requires {
-                            // slug not set
+                        curseforge {
+                            accessToken = providers.environmentVariable("TEST_TOKEN_THAT_DOES_NOT_EXISTS")
+                            projectId = "123456"
+                            minecraftVersions.add("1.20.1")
+                            requires {
+                                // slug not set
+                            }
                         }
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishCurseforge")
+                    """.trimIndent(),
+                ).run("publishCurseforge")
 
         assertContains(result.output, "Dependency slug cannot be null or blank")
     }
 
     @Test
     fun additionalFilesFromSubProject() {
-        val server = MockWebServer(MockCurseforgeApi())
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "<p>Hello!</p>"
+                        version = "1.0.0"
+                        type = BETA
+                        modLoaders.add("fabric")
+                    
+                        curseforge {
+                            accessToken = "123"
+                            projectId = "123456"
+                            minecraftVersions.add("1.20.1")
+                            
+                            additionalFile(project(":fabric")) {
+                                name = "Fabric"
+                            }
 
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "<p>Hello!</p>"
-                    version = "1.0.0"
-                    type = BETA
-                    modLoaders.add("fabric")
-                
-                    curseforge {
-                        accessToken = "123"
-                        projectId = "123456"
-                        minecraftVersions.add("1.20.1")
-                        
-                        additionalFile(project(":fabric")) {
-                            name = "Fabric"
+                            additionalFile(project(":forge")) {
+                                name = "Forge"
+                            }
+
+                            apiEndpoint = "${server.endpoint}"
                         }
-
-                        additionalFile(project(":forge")) {
-                            name = "Forge"
-                        }
-
-                        apiEndpoint = "${server.endpoint}"
                     }
-                }
-                """.trimIndent(),
-            )
-            .subProject("fabric")
-            .subProject("forge")
-            .run("publishCurseforge")
-        server.close()
+                    """.trimIndent(),
+                ).subProject("fabric")
+                .subProject("forge")
+                .run("publishCurseforge")
 
         val metadata = server.api.allMetadata
 

--- a/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeVersionsTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeVersionsTest.kt
@@ -5,38 +5,41 @@ import me.modmuss50.mpp.platforms.curseforge.CurseforgeVersions
 import org.gradle.api.JavaVersion
 import org.junit.jupiter.api.Test
 import java.io.BufferedReader
+import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 
 class CurseforgeVersionsTest {
     val json = Json { ignoreUnknownKeys = true }
 
+    private lateinit var versions: CurseforgeVersions
+
+    @BeforeTest
+    fun setup() {
+        versions = createVersions()
+    }
+
     @Test
     fun minecraftVersions() {
-        val versions = createVersions()
         assertEquals(9990, versions.getMinecraftVersion("1.20.1"))
     }
 
     @Test
     fun modLoader() {
-        val versions = createVersions()
         assertEquals(7499, versions.getModLoaderVersion("fabric"))
     }
 
     @Test
     fun client() {
-        val versions = createVersions()
         assertEquals(9638, versions.getClientVersion())
     }
 
     @Test
     fun server() {
-        val versions = createVersions()
         assertEquals(9639, versions.getServerVersion())
     }
 
     @Test
     fun javaVersions() {
-        val versions = createVersions()
         assertEquals(4458, versions.getJavaVersion(JavaVersion.VERSION_1_8))
         assertEquals(8320, versions.getJavaVersion(JavaVersion.VERSION_11))
         assertEquals(8326, versions.getJavaVersion(JavaVersion.VERSION_17))

--- a/src/test/kotlin/me/modmuss50/mpp/test/discord/DiscordTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/discord/DiscordTest.kt
@@ -7,6 +7,8 @@ import me.modmuss50.mpp.test.curseforge.MockCurseforgeApi
 import me.modmuss50.mpp.test.github.MockGithubApi
 import me.modmuss50.mpp.test.modrinth.MockModrinthApi
 import org.gradle.testkit.runner.TaskOutcome
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -15,48 +17,58 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DiscordTest : IntegrationTest {
+    private lateinit var discordApi: MockDiscordApi
+    private lateinit var server: MockWebServer<MockWebServer.CombinedApi>
+
+    @BeforeTest
+    fun setup() {
+        discordApi = MockDiscordApi()
+        server = MockWebServer(MockWebServer.CombinedApi(listOf(discordApi, MockCurseforgeApi(), MockModrinthApi(), MockGithubApi())))
+    }
+
+    @AfterTest
+    fun cleanup() {
+        server.close()
+    }
+
     @Test
     fun announceWebhook() {
-        val discordApi = MockDiscordApi()
-        val server = MockWebServer(MockWebServer.CombinedApi(listOf(discordApi, MockCurseforgeApi(), MockModrinthApi(), MockGithubApi())))
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "# Changelog\n-123\n-epic feature"
-                    version = "1.0.0"
-                    type = BETA
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "# Changelog\n-123\n-epic feature"
+                        version = "1.0.0"
+                        type = BETA
+                        
+                        curseforge {
+                            accessToken = "123"
+                            projectId = "123456"
+                            projectSlug = "test-mod"
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                        
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"                        
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                        
+                        github {
+                            accessToken = "123"
+                            repository = "test/example"
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     
-                    curseforge {
-                        accessToken = "123"
-                        projectId = "123456"
-                        projectSlug = "test-mod"
-                        apiEndpoint = "${server.endpoint}"
+                        discord {
+                            webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
+                        }
                     }
-                    
-                    modrinth {
-                        accessToken = "123"
-                        projectId = "12345678"                        
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                    
-                    github {
-                        accessToken = "123"
-                        repository = "test/example"
-                        commitish = "main"
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                
-                    discord {
-                        webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
-                    }
-                }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         var embeds = discordApi.requests.first().embeds!!
         embeds = embeds.sortedBy { it.url }
@@ -70,47 +82,43 @@ class DiscordTest : IntegrationTest {
 
     @Test
     fun announceWebhookSpecificPlatforms() {
-        val discordApi = MockDiscordApi()
-        val server = MockWebServer(MockWebServer.CombinedApi(listOf(discordApi, MockCurseforgeApi(), MockModrinthApi(), MockGithubApi())))
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "# Changelog\n-123\n-epic feature"
-                    version = "1.0.0"
-                    type = BETA
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "# Changelog\n-123\n-epic feature"
+                        version = "1.0.0"
+                        type = BETA
+                        
+                        curseforge {
+                            accessToken = "123"
+                            projectId = "123456"
+                            projectSlug = "test-mod"
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                        
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"                        
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                        
+                        github {
+                            accessToken = "123"
+                            repository = "test/example"
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     
-                    curseforge {
-                        accessToken = "123"
-                        projectId = "123456"
-                        projectSlug = "test-mod"
-                        apiEndpoint = "${server.endpoint}"
+                        discord {
+                            webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
+                            setPlatforms(platforms.get("curseforge"), platforms.get("github"))
+                        }
                     }
-                    
-                    modrinth {
-                        accessToken = "123"
-                        projectId = "12345678"                        
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                    
-                    github {
-                        accessToken = "123"
-                        repository = "test/example"
-                        commitish = "main"
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                
-                    discord {
-                        webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
-                        setPlatforms(platforms.get("curseforge"), platforms.get("github"))
-                    }
-                }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         var embeds = discordApi.requests.first().embeds!!
         embeds = embeds.sortedBy { it.url }
@@ -123,60 +131,56 @@ class DiscordTest : IntegrationTest {
 
     @Test
     fun announceWebhookTitle() {
-        val discordApi = MockDiscordApi()
-        val server = MockWebServer(MockWebServer.CombinedApi(listOf(discordApi, MockCurseforgeApi(), MockModrinthApi(), MockGithubApi())))
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                val fabricJar = tasks.register("fabricJar", Jar::class.java) {
-                    archiveClassifier = "fabric"
-                }
-                val forgeJar = tasks.register("forgeJar", Jar::class.java) {
-                    archiveClassifier = "forge"
-                }
-
-                publishMods {
-                    changelog = "Hello!"
-                    version = "1.0.0"
-                    type = BETA
-                
-                    // Common options that can be re-used between diffrent curseforge tasks
-                    val options = curseforgeOptions {
-                        accessToken = "123"
-                        minecraftVersions.add("1.20.1")
-                        apiEndpoint = "${server.endpoint}"
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    val fabricJar = tasks.register("fabricJar", Jar::class.java) {
+                        archiveClassifier = "fabric"
                     }
-                
-                    curseforge("curseforgeFabric") {
-                        from(options)
-                        file = fabricJar.flatMap { it.archiveFile }
-                        projectId = "123456"
-                        modLoaders.add("fabric")
-                        requires {
-                            slug = "fabric-api"
+                    val forgeJar = tasks.register("forgeJar", Jar::class.java) {
+                        archiveClassifier = "forge"
+                    }
+
+                    publishMods {
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = BETA
+                    
+                        // Common options that can be re-used between diffrent curseforge tasks
+                        val options = curseforgeOptions {
+                            accessToken = "123"
+                            minecraftVersions.add("1.20.1")
+                            apiEndpoint = "${server.endpoint}"
                         }
-                        announcementTitle = "Download for Fabric"
-                        projectSlug = "fabric"
-                    }
                     
-                    curseforge("curseforgeForge") {
-                        from(options)
-                        file = forgeJar.flatMap { it.archiveFile }
-                        projectId = "789123"
-                        modLoaders.add("forge")
-                        announcementTitle = "Download for Forge"
-                        projectSlug = "forge"
+                        curseforge("curseforgeFabric") {
+                            from(options)
+                            file = fabricJar.flatMap { it.archiveFile }
+                            projectId = "123456"
+                            modLoaders.add("fabric")
+                            requires {
+                                slug = "fabric-api"
+                            }
+                            announcementTitle = "Download for Fabric"
+                            projectSlug = "fabric"
+                        }
+                        
+                        curseforge("curseforgeForge") {
+                            from(options)
+                            file = forgeJar.flatMap { it.archiveFile }
+                            projectId = "789123"
+                            modLoaders.add("forge")
+                            announcementTitle = "Download for Forge"
+                            projectSlug = "forge"
+                        }
+                        
+                        discord {
+                            webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
+                        }
                     }
-                    
-                    discord {
-                        webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
-                    }
-                }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         var embeds = discordApi.requests.first().embeds!!
         embeds = embeds.sortedBy { it.url }
@@ -189,9 +193,6 @@ class DiscordTest : IntegrationTest {
 
     @Test
     fun announceMoreThan10PlatformsEmbed() {
-        val discordApi = MockDiscordApi()
-        val server = MockWebServer(MockWebServer.CombinedApi(listOf(discordApi, MockCurseforgeApi())))
-
         gradleTest()
             .buildScript(
                 """
@@ -216,9 +217,7 @@ class DiscordTest : IntegrationTest {
                     }
                 }
                 """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+            ).run("publishMods")
 
         val requests = discordApi.requests
 
@@ -237,9 +236,6 @@ class DiscordTest : IntegrationTest {
 
     @Test
     fun announceMoreThan25PlatformsButton() {
-        val discordApi = MockDiscordApi()
-        val server = MockWebServer(MockWebServer.CombinedApi(listOf(discordApi, MockCurseforgeApi())))
-
         gradleTest()
             .buildScript(
                 """
@@ -267,9 +263,7 @@ class DiscordTest : IntegrationTest {
                     }
                 }
                 """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+            ).run("publishMods")
 
         val requests = discordApi.requests
 
@@ -283,7 +277,12 @@ class DiscordTest : IntegrationTest {
             assertEquals(5, component.components!!.size)
         }
 
-        val distinctUrls = requests.flatMap { it.components!!.flatMap { (it as DiscordAPI.ActionRow).components!! as List<DiscordAPI.ButtonComponent> } }.distinctBy { it.url }.size
+        val distinctUrls =
+            requests
+                .flatMap {
+                    it.components!!.flatMap { (it as DiscordAPI.ActionRow).components!! as List<DiscordAPI.ButtonComponent> }
+                }.distinctBy { it.url }
+                .size
         assertEquals(60, distinctUrls)
 
         assertNotNull(requests[0].content)
@@ -293,49 +292,45 @@ class DiscordTest : IntegrationTest {
 
     @Test
     fun announceWebhookDryRun() {
-        val discordApi = MockDiscordApi()
-        val server = MockWebServer(MockWebServer.CombinedApi(listOf(discordApi)))
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "# Changelog\n-123\n-epic feature"
-                    version = "1.0.0"
-                    type = BETA
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "# Changelog\n-123\n-epic feature"
+                        version = "1.0.0"
+                        type = BETA
+                        
+                        dryRun = true
+                        
+                        curseforge {
+                            accessToken = "123"
+                            projectId = "123456"
+                            projectSlug = "test-mod"
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                        
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"                        
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                        
+                        github {
+                            accessToken = "123"
+                            repository = "test/example"
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     
-                    dryRun = true
-                    
-                    curseforge {
-                        accessToken = "123"
-                        projectId = "123456"
-                        projectSlug = "test-mod"
-                        apiEndpoint = "${server.endpoint}"
+                        discord {
+                            webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
+                            dryRunWebhookUrl = "${server.endpoint}/api/webhooks/dryrun/def"
+                        }
                     }
-                    
-                    modrinth {
-                        accessToken = "123"
-                        projectId = "12345678"                        
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                    
-                    github {
-                        accessToken = "123"
-                        repository = "test/example"
-                        commitish = "main"
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                
-                    discord {
-                        webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
-                        dryRunWebhookUrl = "${server.endpoint}/api/webhooks/dryrun/def"
-                    }
-                }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         var embeds = discordApi.requests.first().embeds!!
         embeds = embeds.sortedBy { it.url }
@@ -349,58 +344,52 @@ class DiscordTest : IntegrationTest {
 
     @Test
     fun announceChildProjects() {
-        val discordApi = MockDiscordApi()
-        val server = MockWebServer(MockWebServer.CombinedApi(listOf(discordApi, MockCurseforgeApi(), MockModrinthApi())))
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    changelog = "# Changelog\n-123\n-epic feature"
-                    discord {
-                        webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
-                        setPlatformsAllFrom(*project.subprojects.toTypedArray())
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        changelog = "# Changelog\n-123\n-epic feature"
+                        discord {
+                            webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
+                            setPlatformsAllFrom(*project.subprojects.toTypedArray())
+                        }
                     }
-                }
-                """.trimIndent(),
-            )
-            .subProject(
-                "child1",
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "# Changelog\n-123\n-epic feature"
-                    version = "1.0.0"
-                    type = BETA
-                    
-                    curseforge {
-                        accessToken = "123"
-                        projectId = "123456"
-                        projectSlug = "test-mod"
-                        apiEndpoint = "${server.endpoint}"
+                    """.trimIndent(),
+                ).subProject(
+                    "child1",
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "# Changelog\n-123\n-epic feature"
+                        version = "1.0.0"
+                        type = BETA
+                        
+                        curseforge {
+                            accessToken = "123"
+                            projectId = "123456"
+                            projectSlug = "test-mod"
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     }
-                }
-                """.trimIndent(),
-            )
-            .subProject(
-                "child2",
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "# Changelog\n-123\n-epic feature"
-                    version = "1.0.0"
-                    type = BETA
-                    
-                    modrinth {
-                        accessToken = "123"
-                        projectId = "12345678"                        
-                        apiEndpoint = "${server.endpoint}"
+                    """.trimIndent(),
+                ).subProject(
+                    "child2",
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "# Changelog\n-123\n-epic feature"
+                        version = "1.0.0"
+                        type = BETA
+                        
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"                        
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         var embeds = discordApi.requests.first().embeds!!
         embeds = embeds.sortedBy { it.url }
@@ -413,49 +402,45 @@ class DiscordTest : IntegrationTest {
 
     @Test
     fun announceComponents() {
-        val discordApi = MockDiscordApi()
-        val server = MockWebServer(MockWebServer.CombinedApi(listOf(discordApi, MockCurseforgeApi(), MockModrinthApi(), MockGithubApi())))
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "# Changelog\n-123\n-epic feature"
-                    version = "1.0.0"
-                    type = BETA
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "# Changelog\n-123\n-epic feature"
+                        version = "1.0.0"
+                        type = BETA
+                        
+                        curseforge {
+                            accessToken = "123"
+                            projectId = "123456"
+                            projectSlug = "test-mod"
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                        
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"                        
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                        
+                        github {
+                            accessToken = "123"
+                            repository = "test/example"
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     
-                    curseforge {
-                        accessToken = "123"
-                        projectId = "123456"
-                        projectSlug = "test-mod"
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                    
-                    modrinth {
-                        accessToken = "123"
-                        projectId = "12345678"                        
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                    
-                    github {
-                        accessToken = "123"
-                        repository = "test/example"
-                        commitish = "main"
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                
-                    discord {
-                        webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
-                        style {
-                            link = "BUTTON"
+                        discord {
+                            webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
+                            style {
+                                link = "BUTTON"
+                            }
                         }
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         val first = discordApi.requests.first()
         var components = (first.components!! as List<DiscordAPI.ActionRow>).first().components!! as List<DiscordAPI.ButtonComponent>
@@ -471,49 +456,45 @@ class DiscordTest : IntegrationTest {
 
     @Test
     fun announceInline() {
-        val discordApi = MockDiscordApi()
-        val server = MockWebServer(MockWebServer.CombinedApi(listOf(discordApi, MockCurseforgeApi(), MockModrinthApi(), MockGithubApi())))
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "# Changelog\n-123\n-epic feature"
-                    version = "1.0.0"
-                    type = BETA
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "# Changelog\n-123\n-epic feature"
+                        version = "1.0.0"
+                        type = BETA
+                        
+                        curseforge {
+                            accessToken = "123"
+                            projectId = "123456"
+                            projectSlug = "test-mod"
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                        
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"                        
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                        
+                        github {
+                            accessToken = "123"
+                            repository = "test/example"
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     
-                    curseforge {
-                        accessToken = "123"
-                        projectId = "123456"
-                        projectSlug = "test-mod"
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                    
-                    modrinth {
-                        accessToken = "123"
-                        projectId = "12345678"                        
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                    
-                    github {
-                        accessToken = "123"
-                        repository = "test/example"
-                        commitish = "main"
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                
-                    discord {
-                        webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
-                        style {
-                            link = "INLINE"
+                        discord {
+                            webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
+                            style {
+                                link = "INLINE"
+                            }
                         }
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         val first = discordApi.requests.first()
 
@@ -522,7 +503,11 @@ class DiscordTest : IntegrationTest {
         assertNull(first.components)
         assertNotNull(first.content)
 
-        val links = first.content!!.split("\n").takeLast(3).sortedBy { it }
+        val links =
+            first.content!!
+                .split("\n")
+                .takeLast(3)
+                .sortedBy { it }
         assertEquals("[Download from CurseForge](https://curseforge.com/minecraft/mc-mods/test-mod/files/20402)", links[0])
         assertEquals("[Download from GitHub](https://github.com)", links[1])
         assertEquals("[Download from Modrinth](https://modrinth.com/mod/12345678/version/hFdJG9fY)", links[2])
@@ -530,49 +515,45 @@ class DiscordTest : IntegrationTest {
 
     @Test
     fun announceModern() {
-        val discordApi = MockDiscordApi()
-        val server = MockWebServer(MockWebServer.CombinedApi(listOf(discordApi, MockCurseforgeApi(), MockModrinthApi(), MockGithubApi())))
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "# Changelog\n-123\n-epic feature"
-                    version = "1.0.0"
-                    type = BETA
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "# Changelog\n-123\n-epic feature"
+                        version = "1.0.0"
+                        type = BETA
+                        
+                        curseforge {
+                            accessToken = "123"
+                            projectId = "123456"
+                            projectSlug = "test-mod"
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                        
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"                        
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                        
+                        github {
+                            accessToken = "123"
+                            repository = "test/example"
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     
-                    curseforge {
-                        accessToken = "123"
-                        projectId = "123456"
-                        projectSlug = "test-mod"
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                    
-                    modrinth {
-                        accessToken = "123"
-                        projectId = "12345678"                        
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                    
-                    github {
-                        accessToken = "123"
-                        repository = "test/example"
-                        commitish = "main"
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                
-                    discord {
-                        webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
-                        style {
-                            look = "MODERN"
+                        discord {
+                            webhookUrl = "${server.endpoint}/api/webhooks/213/abc"
+                            style {
+                                look = "MODERN"
+                            }
                         }
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         var embeds = discordApi.requests.first().embeds!!
         embeds = embeds.sortedBy { it.url }

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitea/GiteaTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitea/GiteaTest.kt
@@ -3,19 +3,32 @@ package me.modmuss50.mpp.test.gitea
 import me.modmuss50.mpp.test.IntegrationTest
 import me.modmuss50.mpp.test.MockWebServer
 import org.gradle.testkit.runner.TaskOutcome
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class GiteaTest : IntegrationTest {
+    private lateinit var server: MockWebServer<MockGiteaApi>
+
+    @BeforeTest
+    fun setup() {
+        server = MockWebServer(MockGiteaApi())
+    }
+
+    @AfterTest
+    fun cleanup() {
+        server.close()
+    }
+
     @Test
     fun uploadGitea() {
-        val server = MockWebServer(MockGiteaApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         file = tasks.jar.flatMap { it.archiveFile }
                         changelog = "Hello!"
@@ -29,21 +42,18 @@ class GiteaTest : IntegrationTest {
                             tagName = "release/1.0.0"
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGitea")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGitea")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitea")!!.outcome)
     }
 
     @Test
     fun uploadForgejo() {
-        val server = MockWebServer(MockGiteaApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         file = tasks.jar.flatMap { it.archiveFile }
                         changelog = "Hello!"
@@ -57,22 +67,19 @@ class GiteaTest : IntegrationTest {
                             tagName = "release/1.0.0"
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishForgejo")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishForgejo")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishForgejo")!!.outcome)
     }
 
     @Test
     fun uploadCodeberg() {
-        val server = MockWebServer(MockGiteaApi())
-
         // host(...) call is not needed in production repos since the apiEndpoint is static
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         file = tasks.jar.flatMap { it.archiveFile }
                         changelog = "Hello!"
@@ -86,21 +93,18 @@ class GiteaTest : IntegrationTest {
                             tagName = "release/1.0.0"
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishCodeberg")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishCodeberg")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishCodeberg")!!.outcome)
     }
 
     @Test
     fun noMainFile() {
-        val server = MockWebServer(MockGiteaApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         changelog = "Hello!"
                         version = "1.0.0"
@@ -114,21 +118,18 @@ class GiteaTest : IntegrationTest {
                             additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGitea")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGitea")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitea")!!.outcome)
     }
 
     @Test
     fun uploadGiteaExistingRelease() {
-        val server = MockWebServer(MockGiteaApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         file = tasks.jar.flatMap { it.archiveFile }
                         changelog = "Hello!"
@@ -146,21 +147,18 @@ class GiteaTest : IntegrationTest {
                             parent(tasks.named("publishGitea"))
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGiteaOther")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGiteaOther")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGiteaOther")!!.outcome)
     }
 
     @Test
     fun allowEmptyFiles() {
-        val server = MockWebServer(MockGiteaApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         changelog = "Hello!"
                         version = "1.0.0"
@@ -174,11 +172,10 @@ class GiteaTest : IntegrationTest {
                             allowEmptyFiles = true
                         }
                     }
-                """.trimIndent(),
-            )
-            .subProject(
-                "child",
-                """
+                    """.trimIndent(),
+                ).subProject(
+                    "child",
+                    """
                     publishMods {
                         gitea {
                             accessToken = "123"
@@ -186,10 +183,8 @@ class GiteaTest : IntegrationTest {
                             file = tasks.jar.flatMap { it.archiveFile }
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitea")!!.outcome)
         assertEquals(TaskOutcome.SUCCESS, result.task(":child:publishGitea")!!.outcome)
@@ -197,11 +192,10 @@ class GiteaTest : IntegrationTest {
 
     @Test
     fun allowEmptyFilesDryRun() {
-        val server = MockWebServer(MockGiteaApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         changelog = "Hello!"
                         version = "1.0.0"
@@ -216,21 +210,18 @@ class GiteaTest : IntegrationTest {
                             allowEmptyFiles = true
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGitea")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGitea")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitea")!!.outcome)
     }
 
     @Test
     fun failOnDuplicateNames() {
-        val server = MockWebServer(MockGiteaApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         file = tasks.jar.flatMap { it.archiveFile }
                         changelog = "Hello!"
@@ -245,10 +236,8 @@ class GiteaTest : IntegrationTest {
                             additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGitea")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGitea")
 
         assertEquals(TaskOutcome.FAILED, result.task(":publishGitea")!!.outcome)
         assertContains(result.output, "Gitea file names must be unique within a release, found duplicates: mpp-example.jar")
@@ -256,11 +245,10 @@ class GiteaTest : IntegrationTest {
 
     @Test
     fun failOnParentingGiteaWithForgejo() {
-        val server = MockWebServer(MockGiteaApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         file = tasks.jar.flatMap { it.archiveFile }
                         changelog = "Hello!"
@@ -279,10 +267,8 @@ class GiteaTest : IntegrationTest {
                             parent(tasks.named("publishGitea"))
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGitea")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGitea")
 
         assertNull(result.task(":publishGitea"))
         assertContains(result.output, "Unable to make a Gitea instance a parent of a Forgejo instance")

--- a/src/test/kotlin/me/modmuss50/mpp/test/github/GithubTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/github/GithubTest.kt
@@ -3,18 +3,31 @@ package me.modmuss50.mpp.test.github
 import me.modmuss50.mpp.test.IntegrationTest
 import me.modmuss50.mpp.test.MockWebServer
 import org.gradle.testkit.runner.TaskOutcome
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 class GithubTest : IntegrationTest {
+    private lateinit var server: MockWebServer<MockGithubApi>
+
+    @BeforeTest
+    fun setup() {
+        server = MockWebServer(MockGithubApi())
+    }
+
+    @AfterTest
+    fun cleanup() {
+        server.close()
+    }
+
     @Test
     fun uploadGithub() {
-        val server = MockWebServer(MockGithubApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         file = tasks.jar.flatMap { it.archiveFile }
                         changelog = "Hello!"
@@ -28,21 +41,18 @@ class GithubTest : IntegrationTest {
                             tagName = "release/1.0.0"
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGithub")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGithub")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGithub")!!.outcome)
     }
 
     @Test
     fun noMainFile() {
-        val server = MockWebServer(MockGithubApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         changelog = "Hello!"
                         version = "1.0.0"
@@ -56,21 +66,18 @@ class GithubTest : IntegrationTest {
                             additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGithub")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGithub")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGithub")!!.outcome)
     }
 
     @Test
     fun uploadGithubExistingRelease() {
-        val server = MockWebServer(MockGithubApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         file = tasks.jar.flatMap { it.archiveFile }
                         changelog = "Hello!"
@@ -89,21 +96,18 @@ class GithubTest : IntegrationTest {
                             parent(tasks.named("publishGithub"))
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGithubOther")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGithubOther")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGithubOther")!!.outcome)
     }
 
     @Test
     fun allowEmptyFiles() {
-        val server = MockWebServer(MockGithubApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         changelog = "Hello!"
                         version = "1.0.0"
@@ -117,11 +121,10 @@ class GithubTest : IntegrationTest {
                             allowEmptyFiles = true
                         }
                     }
-                """.trimIndent(),
-            )
-            .subProject(
-                "child",
-                """
+                    """.trimIndent(),
+                ).subProject(
+                    "child",
+                    """
                     publishMods {
                         github {
                             accessToken = "123"
@@ -130,10 +133,8 @@ class GithubTest : IntegrationTest {
                             file = tasks.jar.flatMap { it.archiveFile }
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGithub")!!.outcome)
         assertEquals(TaskOutcome.SUCCESS, result.task(":child:publishGithub")!!.outcome)
@@ -141,11 +142,10 @@ class GithubTest : IntegrationTest {
 
     @Test
     fun allowEmptyFilesDryRun() {
-        val server = MockWebServer(MockGithubApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         changelog = "Hello!"
                         version = "1.0.0"
@@ -160,21 +160,18 @@ class GithubTest : IntegrationTest {
                             allowEmptyFiles = true
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGithub")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGithub")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGithub")!!.outcome)
     }
 
     @Test
     fun failOnDuplicateNames() {
-        val server = MockWebServer(MockGithubApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         file = tasks.jar.flatMap { it.archiveFile }
                         changelog = "Hello!"
@@ -189,10 +186,8 @@ class GithubTest : IntegrationTest {
                             additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGithub")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGithub")
 
         assertEquals(TaskOutcome.FAILED, result.task(":publishGithub")!!.outcome)
         assertContains(result.output, "Github file names must be unique within a release, found duplicates: mpp-example.jar")

--- a/src/test/kotlin/me/modmuss50/mpp/test/gitlab/GitlabTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/gitlab/GitlabTest.kt
@@ -3,18 +3,31 @@ package me.modmuss50.mpp.test.gitlab
 import me.modmuss50.mpp.test.IntegrationTest
 import me.modmuss50.mpp.test.MockWebServer
 import org.gradle.testkit.runner.TaskOutcome
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 class GitlabTest : IntegrationTest {
+    private lateinit var server: MockWebServer<MockGitlabApi>
+
+    @BeforeTest
+    fun setup() {
+        server = MockWebServer(MockGitlabApi())
+    }
+
+    @AfterTest
+    fun cleanup() {
+        server.close()
+    }
+
     @Test
     fun uploadGitlab() {
-        val server = MockWebServer(MockGitlabApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         file = tasks.jar.flatMap { it.archiveFile }
                         changelog = "Hello!"
@@ -28,21 +41,18 @@ class GitlabTest : IntegrationTest {
                             tagName = "release-1.0.0"
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGitlab")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGitlab")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitlab")!!.outcome)
     }
 
     @Test
     fun noMainFile() {
-        val server = MockWebServer(MockGitlabApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         changelog = "Hello!"
                         version = "1.0.0"
@@ -56,21 +66,18 @@ class GitlabTest : IntegrationTest {
                             additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGitlab")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGitlab")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitlab")!!.outcome)
     }
 
     @Test
     fun uploadGitlabExistingRelease() {
-        val server = MockWebServer(MockGitlabApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         file = tasks.jar.flatMap { it.archiveFile }
                         changelog = "Hello!"
@@ -89,21 +96,18 @@ class GitlabTest : IntegrationTest {
                             parent(tasks.named("publishGitlab"))
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGitlabOther")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGitlabOther")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitlabOther")!!.outcome)
     }
 
     @Test
     fun allowEmptyFiles() {
-        val server = MockWebServer(MockGitlabApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         changelog = "Hello!"
                         version = "1.0.0"
@@ -117,11 +121,10 @@ class GitlabTest : IntegrationTest {
                             allowEmptyFiles = true
                         }
                     }
-                """.trimIndent(),
-            )
-            .subProject(
-                "child",
-                """
+                    """.trimIndent(),
+                ).subProject(
+                    "child",
+                    """
                     publishMods {
                         gitlab {
                             accessToken = "123"
@@ -130,10 +133,8 @@ class GitlabTest : IntegrationTest {
                             file = tasks.jar.flatMap { it.archiveFile }
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitlab")!!.outcome)
         assertEquals(TaskOutcome.SUCCESS, result.task(":child:publishGitlab")!!.outcome)
@@ -141,11 +142,10 @@ class GitlabTest : IntegrationTest {
 
     @Test
     fun allowEmptyFilesDryRun() {
-        val server = MockWebServer(MockGitlabApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
                     publishMods {
                         changelog = "Hello!"
                         version = "1.0.0"
@@ -160,41 +160,36 @@ class GitlabTest : IntegrationTest {
                             allowEmptyFiles = true
                         }
                     }
-                """.trimIndent(),
-            )
-            .run("publishGitlab")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGitlab")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishGitlab")!!.outcome)
     }
 
     @Test
     fun failOnDuplicateNames() {
-        val server = MockWebServer(MockGitlabApi())
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
 
-        val result = gradleTest()
-            .buildScript(
-                """
-                publishMods {
-                    file = tasks.jar.flatMap { it.archiveFile }
-                    changelog = "Hello!"
-                    version = "1.0.0"
-                    type = STABLE
+                        gitlab {
+                            accessToken = "123"
+                            projectId = 1
+                            commitish = "main"
+                            apiEndpoint = "${server.endpoint}"
+                            tagName = "release-1.0.0"
 
-                    gitlab {
-                        accessToken = "123"
-                        projectId = 1
-                        commitish = "main"
-                        apiEndpoint = "${server.endpoint}"
-                        tagName = "release-1.0.0"
-
-                        additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
+                            additionalFiles.from(tasks.jar.flatMap { it.archiveFile })
+                        }
                     }
-                }
-                """.trimIndent(),
-            )
-            .run("publishGitlab")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishGitlab")
 
         assertEquals(TaskOutcome.FAILED, result.task(":publishGitlab")!!.outcome)
         assertContains(result.output, "GitLab file names must be unique within a release, found duplicates: mpp-example.jar")

--- a/src/test/kotlin/me/modmuss50/mpp/test/misc/MinecraftApiTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/misc/MinecraftApiTest.kt
@@ -2,76 +2,67 @@ package me.modmuss50.mpp.test.misc
 
 import me.modmuss50.mpp.MinecraftApi
 import me.modmuss50.mpp.test.MockWebServer
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertFalse
 
 class MinecraftApiTest {
+    private lateinit var minecraftApi: MinecraftApi
+    private lateinit var server: MockWebServer<MockMinecraftApi>
+
+    @BeforeTest
+    fun setup() {
+        minecraftApi = MinecraftApi()
+        server = MockWebServer(MockMinecraftApi())
+    }
+
+    @AfterTest
+    fun cleanup() {
+        server.close()
+    }
+
     @Test
     fun getVersions() {
-        val server = MockWebServer(MockMinecraftApi())
-        val api = MinecraftApi(server.endpoint)
-
-        val versions = api.getVersionsInRange("1.19.4", "1.20.1")
+        val versions = minecraftApi.getVersionsInRange("1.19.4", "1.20.1")
         assertContains(versions, "1.19.4")
         assertContains(versions, "1.20")
         assertContains(versions, "1.20.1")
         assertFalse(versions.contains("1.20-rc1"))
-
-        server.close()
     }
 
     @Test
     fun getVersionsSnapshots() {
-        val server = MockWebServer(MockMinecraftApi())
-        val api = MinecraftApi(server.endpoint)
-
-        val versions = api.getVersionsInRange("1.19.4", "1.20.1", true)
+        val versions = minecraftApi.getVersionsInRange("1.19.4", "1.20.1", true)
         assertContains(versions, "1.19.4")
         assertContains(versions, "1.20")
         assertContains(versions, "1.20.1")
         assertContains(versions, "1.20-rc1")
-
-        server.close()
     }
 
     @Test
     fun getVersionsLatest() {
-        val server = MockWebServer(MockMinecraftApi())
-        val api = MinecraftApi(server.endpoint)
-
-        val versions = api.getVersionsInRange("1.19.4", "latest")
+        val versions = minecraftApi.getVersionsInRange("1.19.4", "latest")
         assertContains(versions, "1.19.4")
         assertContains(versions, "1.20")
         assertContains(versions, "1.20.2")
         assertFalse(versions.contains("23w44a"))
-
-        server.close()
     }
 
     @Test
     fun getVersionsLatestSnapshot() {
-        val server = MockWebServer(MockMinecraftApi())
-        val api = MinecraftApi(server.endpoint)
-
-        val versions = api.getVersionsInRange("1.19.4", "latest", true)
+        val versions = minecraftApi.getVersionsInRange("1.19.4", "latest", true)
         assertContains(versions, "1.19.4")
         assertContains(versions, "1.20")
         assertContains(versions, "1.20.2")
         assertContains(versions, "23w44a")
-
-        server.close()
     }
 
     @Test
     fun getSingleVersionFromRange() {
-        val server = MockWebServer(MockMinecraftApi())
-        val api = MinecraftApi(server.endpoint)
-
-        val versions = api.getVersionsInRange("1.19.4", "1.19.4", true)
+        val versions = minecraftApi.getVersionsInRange("1.19.4", "1.19.4", true)
         assert(versions.size == 1)
         assertContains(versions, "1.19.4")
-
-        server.close()
     }
 }

--- a/src/test/kotlin/me/modmuss50/mpp/test/modrinth/ModrinthTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/modrinth/ModrinthTest.kt
@@ -3,86 +3,96 @@ package me.modmuss50.mpp.test.modrinth
 import me.modmuss50.mpp.test.IntegrationTest
 import me.modmuss50.mpp.test.MockWebServer
 import org.gradle.testkit.runner.TaskOutcome
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class ModrinthTest : IntegrationTest {
+    private lateinit var modrinthApi: MockModrinthApi
+    private lateinit var server: MockWebServer<MockModrinthApi>
+
+    @BeforeTest
+    fun setup() {
+        modrinthApi = MockModrinthApi()
+        server = MockWebServer(modrinthApi)
+    }
+
+    @AfterTest
+    fun cleanup() {
+        server.close()
+    }
+
     @Test
     fun uploadModrinth() {
-        val server = MockWebServer(MockModrinthApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
-            publishMods {
-                file = tasks.jar.flatMap { it.archiveFile }
-                changelog = "Hello!"
-                version = "1.0.0"
-                type = STABLE
-                modLoaders.add("fabric")
-            
-                modrinth {
-                    accessToken = "123"
-                    projectId = "12345678"
-                    minecraftVersions.add("1.20.1")
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        modLoaders.add("fabric")
                     
-                    requires {
-                        id = "P7dR8mSH"
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"
+                            minecraftVersions.add("1.20.1")
+                            
+                            requires {
+                                id = "P7dR8mSH"
+                            }
+                            
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     }
-                    
-                    apiEndpoint = "${server.endpoint}"
-                }
-            }
-                """.trimIndent(),
-            )
-            .run("publishModrinth")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishModrinth")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishModrinth")!!.outcome)
     }
 
     @Test
     fun uploadModrinthWithOptions() {
-        val server = MockWebServer(MockModrinthApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
-                version = "1.0.0"
-                publishMods {
-                    changelog = "Hello!"
-                    type = BETA
-                
-                    // Common options that can be re-used between diffrent modrinth tasks
-                    val modrinthOptions = modrinthOptions {
-                        accessToken = "123"
-                        minecraftVersions.add("1.20.1")
-                        apiEndpoint = "${server.endpoint}"
-                    }
-                
-                    modrinth("modrinthFabric") {
-                        from(modrinthOptions)
-                        file = tasks.jar.flatMap { it.archiveFile }
-                        projectId = "12345678"
-                        modLoaders.add("fabric")
-                        requires {
-                           id = "P7dR8mSH" // fabric-api
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    version = "1.0.0"
+                    publishMods {
+                        changelog = "Hello!"
+                        type = BETA
+                    
+                        // Common options that can be re-used between diffrent modrinth tasks
+                        val modrinthOptions = modrinthOptions {
+                            accessToken = "123"
+                            minecraftVersions.add("1.20.1")
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                    
+                        modrinth("modrinthFabric") {
+                            from(modrinthOptions)
+                            file = tasks.jar.flatMap { it.archiveFile }
+                            projectId = "12345678"
+                            modLoaders.add("fabric")
+                            requires {
+                               id = "P7dR8mSH" // fabric-api
+                            }
+                        }
+                        
+                        modrinth("modrinthForge") {
+                            from(modrinthOptions)
+                            file = tasks.jar.flatMap { it.archiveFile }
+                            projectId = "67896545"
+                            modLoaders.add("forge")
                         }
                     }
-                    
-                    modrinth("modrinthForge") {
-                        from(modrinthOptions)
-                        file = tasks.jar.flatMap { it.archiveFile }
-                        projectId = "67896545"
-                        modLoaders.add("forge")
-                    }
-                }
-                """.trimIndent(),
-            )
-            .run("publishMods")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishMods")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishModrinthFabric")!!.outcome)
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishModrinthForge")!!.outcome)
@@ -90,89 +100,83 @@ class ModrinthTest : IntegrationTest {
 
     @Test
     fun dryRunModrinth() {
-        val result = gradleTest()
-            .buildScript(
-                """
-            publishMods {
-                file = tasks.jar.flatMap { it.archiveFile }
-                changelog = "Hello!"
-                version = "1.0.0"
-                type = STABLE
-                modLoaders.add("fabric")
-                dryRun = true
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        modLoaders.add("fabric")
+                        dryRun = true
 
-                modrinth {
-                    accessToken = providers.environmentVariable("TEST_TOKEN_THAT_DOES_NOT_EXISTS")
-                    projectId = "12345678"
-                    minecraftVersions.add("1.20.1")
-                    requires {
-                           id = "P7dR8mSH" // fabric-api
+                        modrinth {
+                            accessToken = providers.environmentVariable("TEST_TOKEN_THAT_DOES_NOT_EXISTS")
+                            projectId = "12345678"
+                            minecraftVersions.add("1.20.1")
+                            requires {
+                                   id = "P7dR8mSH" // fabric-api
+                            }
+                        }
                     }
-                }
-            }
-                """.trimIndent(),
-            )
-            .run("publishModrinth")
+                    """.trimIndent(),
+                ).run("publishModrinth")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishModrinth")!!.outcome)
     }
 
     @Test
     fun uploadModrinthNoDeps() {
-        val server = MockWebServer(MockModrinthApi())
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        modLoaders.add("fabric")
+                    
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"
+                            minecraftVersions.add("1.20.1")
 
-        val result = gradleTest()
-            .buildScript(
-                """
-            publishMods {
-                file = tasks.jar.flatMap { it.archiveFile }
-                changelog = "Hello!"
-                version = "1.0.0"
-                type = STABLE
-                modLoaders.add("fabric")
-            
-                modrinth {
-                    accessToken = "123"
-                    projectId = "12345678"
-                    minecraftVersions.add("1.20.1")
-
-                    apiEndpoint = "${server.endpoint}"
-                }
-            }
-                """.trimIndent(),
-            )
-            .run("publishModrinth")
-        server.close()
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                    }
+                    """.trimIndent(),
+                ).run("publishModrinth")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishModrinth")!!.outcome)
     }
 
     @Test
     fun invalidId() {
-        val server = MockWebServer(MockModrinthApi())
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        modLoaders.add("fabric")
+                    
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "invalid-id"
+                            minecraftVersions.add("1.20.1")
 
-        val result = gradleTest()
-            .buildScript(
-                """
-            publishMods {
-                file = tasks.jar.flatMap { it.archiveFile }
-                changelog = "Hello!"
-                version = "1.0.0"
-                type = STABLE
-                modLoaders.add("fabric")
-            
-                modrinth {
-                    accessToken = "123"
-                    projectId = "invalid-id"
-                    minecraftVersions.add("1.20.1")
-
-                    apiEndpoint = "${server.endpoint}"
-                }
-            }
-                """.trimIndent(),
-            )
-            .run("publishModrinth")
-        server.close()
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                    }
+                    """.trimIndent(),
+                ).run("publishModrinth")
 
         assertEquals(TaskOutcome.FAILED, result.task(":publishModrinth")!!.outcome)
         result.output.contains("invalid-id is not a valid Modrinth ID")
@@ -180,73 +184,66 @@ class ModrinthTest : IntegrationTest {
 
     @Test
     fun uploadModrinthSlugLookup() {
-        val server = MockWebServer(MockModrinthApi())
-
-        val result = gradleTest()
-            .buildScript(
-                """
-            publishMods {
-                file = tasks.jar.flatMap { it.archiveFile }
-                changelog = "Hello!"
-                version = "1.0.0"
-                type = STABLE
-                modLoaders.add("fabric")
-            
-                modrinth {
-                    accessToken = "123"
-                    projectId = "12345678"
-                    minecraftVersions.add("1.20.1")
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        modLoaders.add("fabric")
                     
-                    requires {
-                        slug = "fabric-api"
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"
+                            minecraftVersions.add("1.20.1")
+                            
+                            requires {
+                                slug = "fabric-api"
+                            }
+                            
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     }
-                    
-                    apiEndpoint = "${server.endpoint}"
-                }
-            }
-                """.trimIndent(),
-            )
-            .run("publishModrinth")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishModrinth")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishModrinth")!!.outcome)
     }
 
     @Test
     fun uploadModrinthMinecraftVersionRange() {
-        val mockModrinthApi = MockModrinthApi()
-        val server = MockWebServer(mockModrinthApi)
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        modLoaders.add("fabric")
+                    
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"
 
-        val result = gradleTest()
-            .buildScript(
-                """
-            publishMods {
-                file = tasks.jar.flatMap { it.archiveFile }
-                changelog = "Hello!"
-                version = "1.0.0"
-                type = STABLE
-                modLoaders.add("fabric")
-            
-                modrinth {
-                    accessToken = "123"
-                    projectId = "12345678"
+                            minecraftVersionRange {
+                                start = "1.13.1" // test WALL_OF_SHAME
+                                end = "1.20.2"
+                                includeSnapshots = true
+                            }
 
-                    minecraftVersionRange {
-                        start = "1.13.1" // test WALL_OF_SHAME
-                        end = "1.20.2"
-                        includeSnapshots = true
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     }
-
-                    apiEndpoint = "${server.endpoint}"
-                }
-            }
-                """.trimIndent(),
-            )
-            .run("publishModrinth")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishModrinth")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishModrinth")!!.outcome)
-        val gameVersions = mockModrinthApi.lastCreateVersion!!.gameVersions
+        val gameVersions = modrinthApi.lastCreateVersion!!.gameVersions
         assertContains(gameVersions, "1.13.1")
         assertContains(gameVersions, "1.14.2-pre4")
         assertContains(gameVersions, "1.20-pre1")
@@ -256,35 +253,31 @@ class ModrinthTest : IntegrationTest {
 
     @Test
     fun uploadModrinthMinecraftVersionList() {
-        val mockModrinthApi = MockModrinthApi()
-        val server = MockWebServer(mockModrinthApi)
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        modLoaders.add("fabric")
+                    
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"
 
-        val result = gradleTest()
-            .buildScript(
-                """
-            publishMods {
-                file = tasks.jar.flatMap { it.archiveFile }
-                changelog = "Hello!"
-                version = "1.0.0"
-                type = STABLE
-                modLoaders.add("fabric")
-            
-                modrinth {
-                    accessToken = "123"
-                    projectId = "12345678"
+                            minecraftVersionList("26.1, 26.1.1, 26.1.2, 26.2-snapshot-1")
 
-                    minecraftVersionList("26.1, 26.1.1, 26.1.2, 26.2-snapshot-1")
-
-                    apiEndpoint = "${server.endpoint}"
-                }
-            }
-                """.trimIndent(),
-            )
-            .run("publishModrinth")
-        server.close()
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                    }
+                    """.trimIndent(),
+                ).run("publishModrinth")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishModrinth")!!.outcome)
-        val gameVersions = mockModrinthApi.lastCreateVersion!!.gameVersions
+        val gameVersions = modrinthApi.lastCreateVersion!!.gameVersions
         assertContains(gameVersions, "26.1")
         assertContains(gameVersions, "26.1.1")
         assertContains(gameVersions, "26.1.2")
@@ -293,38 +286,34 @@ class ModrinthTest : IntegrationTest {
 
     @Test
     fun uploadModrinthMinecraftVersionRangeNoSnapshots() {
-        val mockModrinthApi = MockModrinthApi()
-        val server = MockWebServer(mockModrinthApi)
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        modLoaders.add("fabric")
+                    
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"
 
-        val result = gradleTest()
-            .buildScript(
-                """
-            publishMods {
-                file = tasks.jar.flatMap { it.archiveFile }
-                changelog = "Hello!"
-                version = "1.0.0"
-                type = STABLE
-                modLoaders.add("fabric")
-            
-                modrinth {
-                    accessToken = "123"
-                    projectId = "12345678"
+                            minecraftVersionRange {
+                                start = "1.19.4"
+                                end = "1.20.2"
+                            }
 
-                    minecraftVersionRange {
-                        start = "1.19.4"
-                        end = "1.20.2"
+                            apiEndpoint = "${server.endpoint}"
+                        }
                     }
-
-                    apiEndpoint = "${server.endpoint}"
-                }
-            }
-                """.trimIndent(),
-            )
-            .run("publishModrinth")
-        server.close()
+                    """.trimIndent(),
+                ).run("publishModrinth")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishModrinth")!!.outcome)
-        val gameVersions = mockModrinthApi.lastCreateVersion!!.gameVersions
+        val gameVersions = modrinthApi.lastCreateVersion!!.gameVersions
         assertContains(gameVersions, "1.19.4")
         assertFalse(gameVersions.contains("1.20-pre1"))
         assertContains(gameVersions, "1.20.1")
@@ -333,105 +322,98 @@ class ModrinthTest : IntegrationTest {
 
     @Test
     fun updateProjectDescription() {
-        val api = MockModrinthApi()
-        val server = MockWebServer(api)
-
-        val result = gradleTest()
-            .buildScript(
-                """
-            publishMods {
-                file = tasks.jar.flatMap { it.archiveFile }
-                changelog = "Hello!"
-                version = "1.0.0"
-                type = STABLE
-                modLoaders.add("fabric")
-            
-                modrinth {
-                    accessToken = "123"
-                    projectId = "12345678"
-                    minecraftVersions.add("1.20.1")
-                    projectDescription = providers.fileContents(layout.projectDirectory.file("readme.md")).asText
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        modLoaders.add("fabric")
                     
-                    apiEndpoint = "${server.endpoint}"
-                }
-            }
-                """.trimIndent(),
-            )
-            .file("readme.md", "Hello World")
-            .run("publishModrinth")
-        server.close()
+                        modrinth {
+                            accessToken = "123"
+                            projectId = "12345678"
+                            minecraftVersions.add("1.20.1")
+                            projectDescription = providers.fileContents(layout.projectDirectory.file("readme.md")).asText
+                            
+                            apiEndpoint = "${server.endpoint}"
+                        }
+                    }
+                    """.trimIndent(),
+                ).file("readme.md", "Hello World")
+                .run("publishModrinth")
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishModrinth")!!.outcome)
-        assertEquals("Hello World", api.projectBody)
+        assertEquals("Hello World", modrinthApi.projectBody)
     }
 
     @Test
     fun invalidDependency() {
-        val result = gradleTest()
-            .buildScript(
-                """
-            publishMods {
-                file = tasks.jar.flatMap { it.archiveFile }
-                changelog = "Hello!"
-                version = "1.0.0"
-                type = STABLE
-                modLoaders.add("fabric")
-                dryRun = true
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        modLoaders.add("fabric")
+                        dryRun = true
 
-                modrinth {
-                    accessToken = providers.environmentVariable("TEST_TOKEN_THAT_DOES_NOT_EXISTS")
-                    projectId = "12345678"
-                    minecraftVersions.add("1.20.1")
-                    requires {
-                        // neither id nor slug set
+                        modrinth {
+                            accessToken = providers.environmentVariable("TEST_TOKEN_THAT_DOES_NOT_EXISTS")
+                            projectId = "12345678"
+                            minecraftVersions.add("1.20.1")
+                            requires {
+                                // neither id nor slug set
+                            }
+                        }
                     }
-                }
-            }
-                """.trimIndent(),
-            )
-            .run("publishModrinth")
+                    """.trimIndent(),
+                ).run("publishModrinth")
 
         assertContains(result.output, "Modrinth dependency must have either an id or slug specified")
     }
 
     @Test
     fun uploadModrinthSlugDependency() {
-        val mockModrinthApi = MockModrinthApi()
-        val server = MockWebServer(mockModrinthApi)
-
-        val result = gradleTest()
-            .buildScript(
-                """
-            publishMods {
-                file = tasks.jar.flatMap { it.archiveFile }
-                changelog = "Hello!"
-                version = "1.0.0"
-                type = STABLE
-                
-                modrinth {
-                    accessToken = "123"
-                    minecraftVersions.add("1.20.1")
-                    apiEndpoint = "${server.endpoint}"
-                    projectId = "67896545"
-                    modLoaders.add("fabric")
-                    requires {
-                        id = "P7dR8mSH"
-                        version = "P7uGFii0"
+        val result =
+            gradleTest()
+                .buildScript(
+                    """
+                    publishMods {
+                        file = tasks.jar.flatMap { it.archiveFile }
+                        changelog = "Hello!"
+                        version = "1.0.0"
+                        type = STABLE
+                        
+                        modrinth {
+                            accessToken = "123"
+                            minecraftVersions.add("1.20.1")
+                            apiEndpoint = "${server.endpoint}"
+                            projectId = "67896545"
+                            modLoaders.add("fabric")
+                            requires {
+                                id = "P7dR8mSH"
+                                version = "P7uGFii0"
+                            }
+                            requires {
+                                slug = "fabric-api"
+                                version = "0.92.1+1.20.1"
+                            }
+                        }
                     }
-                    requires {
-                        slug = "fabric-api"
-                        version = "0.92.1+1.20.1"
-                    }
-                }
-            }
-                """.trimIndent(),
-            )
-            .run("publishMods")
+                    """.trimIndent(),
+                ).run("publishMods")
         server.close()
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":publishModrinth")!!.outcome)
 
-        var dependencies = mockModrinthApi.lastCreateVersion!!.dependencies.map { it.versionId }
+        var dependencies = modrinthApi.lastCreateVersion!!.dependencies.map { it.versionId }
         assertEquals(2, dependencies.size)
         assertContains(dependencies, "P7uGFii0")
         assertContains(dependencies, "ba99D9Qf")


### PR DESCRIPTION
Switched to using Kotlin's 'BeforeTest' and 'AfterTest' annotations to initialize test variables and perform post-test cleanup. Provides a bit of a safety net with functions such as server.close() and makes the tests themselves a bit simpler. Might also want to consider letting Javalin pick an empty port for the test server rather than hard coding 9082 because it can fail on some systems.