### PR TITLE
DRAFT: Replace Java Http with Ktor & CIO

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 
     testImplementation(kotlin("test"))
-    testImplementation("io.javalin:javalin:7.2.0")
+    testImplementation("io.ktor:ktor-server-test-host:3.4.3")
     testImplementation("org.junit.jupiter:junit-jupiter:6.0.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,9 @@ repositories {
 
 dependencies {
     implementation(gradleApi())
+    implementation("io.ktor:ktor-client-core:3.4.3")
+    implementation("io.ktor:ktor-client-cio:3.4.3")
+    implementation("io.ktor:ktor-client-content-negotiation:3.4.3")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 
     testImplementation(kotlin("test"))
@@ -37,12 +40,13 @@ kotlin {
 
 // Workaround https://github.com/gradle/gradle/issues/25898
 tasks.withType(Test::class.java).configureEach {
-    jvmArgs = listOf(
-        "--add-opens=java.base/java.lang=ALL-UNNAMED",
-        "--add-opens=java.base/java.util=ALL-UNNAMED",
-        "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
-        "--add-opens=java.base/java.net=ALL-UNNAMED"
-    )
+    jvmArgs =
+        listOf(
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED",
+            "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+            "--add-opens=java.base/java.net=ALL-UNNAMED",
+        )
 }
 
 tasks.withType(JavaCompile::class.java).all {
@@ -81,7 +85,7 @@ gradlePlugin {
         displayName = "Mod Publish Plugin"
         description = project.description
         version = project.version
-        tags = listOf("minecraft", )
+        tags = listOf("minecraft")
         compatibility {
             features {
                 configurationCache = true
@@ -93,7 +97,7 @@ gradlePlugin {
 fun replaceVersion(path: String) {
     var content = project.file(path).readText()
 
-    content = content.replace("(version \").*(\")".toRegex(), "version \"${project.version}\"")// project.version.toString())
+    content = content.replace("(version \").*(\")".toRegex(), "version \"${project.version}\"") // project.version.toString())
 
     project.file(path).writeText(content)
 }

--- a/src/main/kotlin/me/modmuss50/mpp/Platform.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/Platform.kt
@@ -11,7 +11,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.jetbrains.annotations.ApiStatus
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 import kotlin.reflect.KClass
 

--- a/src/main/kotlin/me/modmuss50/mpp/PlatformInternal.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/PlatformInternal.kt
@@ -2,7 +2,6 @@ package me.modmuss50.mpp
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.gradle.api.Action
 import org.gradle.api.file.RegularFile

--- a/src/main/kotlin/me/modmuss50/mpp/PublishModTask.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/PublishModTask.kt
@@ -1,6 +1,5 @@
 package me.modmuss50.mpp
 
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import me.modmuss50.mpp.platforms.gitea.base.GiteaCompatibleOptions
 import me.modmuss50.mpp.platforms.github.GithubOptions

--- a/src/main/kotlin/me/modmuss50/mpp/networking/DefaultHttpImpl.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/networking/DefaultHttpImpl.kt
@@ -1,32 +1,37 @@
 package me.modmuss50.mpp.networking
 
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.endpoint
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import java.net.http.HttpClient
-import java.time.Duration
 
 object DefaultHttpImpl {
     val defaultJson = Json { ignoreUnknownKeys = true }
-    val defaultAgent = "modmuss50/mod-publish-plugin/${DefaultHttpImpl::class.java.`package`.implementationVersion}"
-    val defaultClient = client(Duration.ofSeconds(30))
+
+    val defaultAgent =
+        "modmuss50/mod-publish-plugin/${DefaultHttpImpl::class.java.`package`.implementationVersion}"
+
+    val defaultClient = client(java.time.Duration.ofSeconds(30))
 
     val defaultExceptionFactory: HttpExceptionFactory = { response ->
-        val body = response.body().orEmpty()
+        val body = response.body<String>()
 
         val message =
             buildString {
-                append("Request failed (status: ${response.statusCode()}, url: ${response.uri()})")
+                append("Request failed (status: ${response.status.value}, url: ${response.call.request.url})")
                 if (body.isNotBlank()) {
                     append(" message: $body")
                 }
             }
 
         HttpException(
-            statusCode = response.statusCode(),
-            uri = response.uri(),
+            statusCode = response.status.value,
+            url = response.call.request.url,
             body = body,
-            headers = response.headers().map(),
-            response = response,
+            headers =
+                response.headers
+                    .entries()
+                    .associate { it.key to it.value },
             message = message,
         )
     }
@@ -41,15 +46,20 @@ object DefaultHttpImpl {
 
     val defaultConfig = HttpConfig(defaultProfile)
 
-    fun client(timeout: Duration) =
-        HttpClient
-            .newBuilder()
-            .connectTimeout(timeout)
-            .build()
+    fun client(timeout: java.time.Duration) =
+        io.ktor.client.HttpClient(io.ktor.client.engine.cio.CIO) {
+            engine {
+                requestTimeout = timeout.toMillis()
+                endpoint {
+                    connectTimeout = timeout.toMillis()
+                }
+            }
+        }
 
     inline fun <reified T> jsonErrorFactory(crossinline messageExtractor: (T) -> String): HttpExceptionFactory =
         { response ->
-            val body = response.body().orEmpty()
+
+            val body = response.body<String>()
             val json = Json { ignoreUnknownKeys = true }
 
             val baseMessage =
@@ -60,14 +70,18 @@ object DefaultHttpImpl {
                     body.ifBlank { "Unknown error" }
                 }
 
-            val message = "${response.statusCode()} ${response.uri()}: $baseMessage"
+            val uri = response.call.request.url
+
+            val message = "${response.status.value} $uri: $baseMessage"
 
             HttpException(
-                statusCode = response.statusCode(),
-                uri = response.uri(),
+                statusCode = response.status.value,
+                url = uri,
                 body = body,
-                headers = response.headers().map(),
-                response = response,
+                headers =
+                    response.headers
+                        .entries()
+                        .associate { it.key to it.value },
                 message = message,
             )
         }

--- a/src/main/kotlin/me/modmuss50/mpp/networking/DefaultHttpImpl.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/networking/DefaultHttpImpl.kt
@@ -1,6 +1,8 @@
 package me.modmuss50.mpp.networking
 
+import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
 import io.ktor.client.engine.cio.endpoint
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -47,7 +49,7 @@ object DefaultHttpImpl {
     val defaultConfig = HttpConfig(defaultProfile)
 
     fun client(timeout: java.time.Duration) =
-        io.ktor.client.HttpClient(io.ktor.client.engine.cio.CIO) {
+        HttpClient(CIO) {
             engine {
                 requestTimeout = timeout.toMillis()
                 endpoint {

--- a/src/main/kotlin/me/modmuss50/mpp/networking/HttpApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/networking/HttpApi.kt
@@ -1,105 +1,71 @@
 package me.modmuss50.mpp.networking
 
-import java.net.URI
-import java.net.http.HttpRequest
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpMethod
 
-/**
- * HTTP API wrapper providing convenient request methods.
- *
- * This class builds on top of [HttpEngine] to expose common HTTP operations
- * such as GET, POST, PUT, and PATCH with minimal boilerplate.
- *
- * @property ctx The HTTP context containing the client, JSON, user agent, and exception factory.
- */
 class HttpApi(
     private val ctx: HttpContext,
 ) {
-    // For now the engine will be owned at the API level...
     private val engine = HttpEngine(ctx)
 
-    /**
-     * The JSON instance used for encoding and decoding request/response bodies.
-     */
     val json get() = ctx.json
 
-    /**
-     * Executes an HTTP GET request and deserializes the response body into type [T].
-     *
-     * @param T The expected response type.
-     * @param url The target URL.
-     * @param headers Additional headers to include in the request.
-     *
-     * @return The deserialized response body as type [T].
-     */
-    internal inline fun <reified T> get(
+    internal suspend inline fun <reified T> get(
         url: String,
         headers: Map<String, String> = emptyMap(),
     ): T =
-        engine.request(
-            HttpRequest.newBuilder().uri(URI.create(url)).GET(),
-            headers,
-        )
+        engine.request<T>(
+            url = url,
+            headers = headers,
+        ) {
+            method = HttpMethod.Get
+        }
 
-    /**
-     * Executes an HTTP POST request with a request body and deserializes the response into type [T].
-     *
-     * @param T The expected response type.
-     * @param url The target URL.
-     * @param body The request body publisher.
-     * @param headers Additional headers to include in the request.
-     *
-     * @return The deserialized response body as type [T].
-     */
-    internal inline fun <reified T> post(
+    internal suspend inline fun <reified T> post(
         url: String,
-        body: HttpRequest.BodyPublisher,
+        body: Any? = null,
         headers: Map<String, String> = emptyMap(),
     ): T =
-        engine.request(
-            HttpRequest.newBuilder().uri(URI.create(url)).POST(body),
-            headers,
-        )
+        engine.request<T>(
+            url = url,
+            headers = headers,
+        ) {
+            method = HttpMethod.Post
 
-    /**
-     * Executes an HTTP PUT request with a request body and deserializes the response into type [T].
-     *
-     * @param T The expected response type.
-     * @param url The target URL.
-     * @param body The request body publisher.
-     * @param headers Additional headers to include in the request.
-     *
-     * @return The deserialized response body as type [T].
-     */
-    internal inline fun <reified T> put(
-        url: String,
-        body: HttpRequest.BodyPublisher,
-        headers: Map<String, String> = emptyMap(),
-    ): T =
-        engine.request(
-            HttpRequest.newBuilder().uri(URI.create(url)).PUT(body),
-            headers,
-        )
+            body?.let {
+                setBody(it)
+            }
+        }
 
-    /**
-     * Executes an HTTP PATCH request with a request body and deserializes the response into type [T].
-     *
-     * Note: PATCH is not directly supported as a dedicated method in [HttpRequest.Builder],
-     * so it is invoked via [HttpRequest.Builder.method].
-     *
-     * @param T The expected response type.
-     * @param url The target URL.
-     * @param body The request body publisher.
-     * @param headers Additional headers to include in the request.
-     *
-     * @return The deserialized response body as type [T].
-     */
-    internal inline fun <reified T> patch(
+    internal suspend inline fun <reified T> put(
         url: String,
-        body: HttpRequest.BodyPublisher,
+        body: Any? = null,
         headers: Map<String, String> = emptyMap(),
     ): T =
-        engine.request(
-            HttpRequest.newBuilder().uri(URI.create(url)).method("PATCH", body),
-            headers,
-        )
+        engine.request<T>(
+            url = url,
+            headers = headers,
+        ) {
+            method = HttpMethod.Put
+
+            body?.let {
+                setBody(it)
+            }
+        }
+
+    internal suspend inline fun <reified T> patch(
+        url: String,
+        body: Any? = null,
+        headers: Map<String, String> = emptyMap(),
+    ): T =
+        engine.request<T>(
+            url = url,
+            headers = headers,
+        ) {
+            method = HttpMethod.Patch
+
+            body?.let {
+                setBody(it)
+            }
+        }
 }

--- a/src/main/kotlin/me/modmuss50/mpp/networking/HttpApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/networking/HttpApi.kt
@@ -10,7 +10,7 @@ class HttpApi(
 
     val json get() = ctx.json
 
-    internal suspend inline fun <reified T> get(
+    internal inline fun <reified T> get(
         url: String,
         headers: Map<String, String> = emptyMap(),
     ): T =
@@ -21,7 +21,7 @@ class HttpApi(
             method = HttpMethod.Get
         }
 
-    internal suspend inline fun <reified T> post(
+    internal inline fun <reified T> post(
         url: String,
         body: Any? = null,
         headers: Map<String, String> = emptyMap(),
@@ -37,7 +37,7 @@ class HttpApi(
             }
         }
 
-    internal suspend inline fun <reified T> put(
+    internal inline fun <reified T> put(
         url: String,
         body: Any? = null,
         headers: Map<String, String> = emptyMap(),
@@ -53,7 +53,7 @@ class HttpApi(
             }
         }
 
-    internal suspend inline fun <reified T> patch(
+    internal inline fun <reified T> patch(
         url: String,
         body: Any? = null,
         headers: Map<String, String> = emptyMap(),

--- a/src/main/kotlin/me/modmuss50/mpp/networking/HttpConfig.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/networking/HttpConfig.kt
@@ -1,20 +1,8 @@
 package me.modmuss50.mpp.networking
 
-/**
- * Configuration holder for HTTP-related infrastructure.
- *
- * This class wraps a base [HttpContext] and exposes a lazily-created [HttpApi]
- * instance derived from that context.
- *
- * @property context The base [HttpContext] containing shared HTTP configuration
- * such as the client, JSON serializer, user agent, and exception factory.
- */
 data class HttpConfig(
     val context: HttpContext,
 ) {
-    /**
-     * Lazily initialized [HttpApi] instance built from the provided [context].
-     */
     val httpApi by lazy {
         HttpApi(
             HttpContext(

--- a/src/main/kotlin/me/modmuss50/mpp/networking/HttpContext.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/networking/HttpContext.kt
@@ -1,16 +1,8 @@
 package me.modmuss50.mpp.networking
 
+import io.ktor.client.HttpClient
 import kotlinx.serialization.json.Json
-import java.net.http.HttpClient
 
-/**
- * Configuration container for internal HTTP operations.
- *
- * @property client The underlying [HttpClient] used to execute requests.
- * @property json The JSON serializer used for encoding and decoding data.
- * @property userAgent The default `User-Agent` header applied to requests.
- * @property exceptionFactory Factory used to convert HTTP responses into [HttpException]s.
- */
 class HttpContext(
     val client: HttpClient,
     val json: Json,

--- a/src/main/kotlin/me/modmuss50/mpp/networking/HttpEngine.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/networking/HttpEngine.kt
@@ -1,61 +1,38 @@
 package me.modmuss50.mpp.networking
 
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.header
+import io.ktor.client.request.request
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
 
-/**
- * A small HTTP execution layer responsible for sending requests and decoding responses.
- *
- * This class wraps a configured [HttpContext] and provides a generic HTTP request method
- *
- * @property ctx The HTTP context containing the client, JSON, user agent, and exception factory.
- */
 class HttpEngine(
     private val ctx: HttpContext,
 ) {
-    /**
-     * Executes an HTTP request and deserializes the response body into type [T].
-     *
-     * @param T The expected response type.
-     * @param builder The [HttpRequest.Builder] used to construct the request.
-     * @param headers Headers to include in the request.
-     *
-     * @return The deserialized response body as type [T].
-     */
-    internal inline fun <reified T> request(
-        builder: HttpRequest.Builder,
+    internal suspend inline fun <reified T> request(
+        url: String,
         headers: Map<String, String> = emptyMap(),
+        block: HttpRequestBuilder.() -> Unit = {},
     ): T {
-        val request =
-            builder
-                .header("User-Agent", ctx.userAgent)
-                .apply { headers.forEach(::header) }
-                .build()
-
         val response =
-            ctx.client
-                .send(request, HttpResponse.BodyHandlers.ofString())
-                .ensureSuccess(ctx.exceptionFactory)
+            ctx.client.request(url) {
+                method = HttpMethod.Get
 
-        val body = response.body()
+                header(HttpHeaders.UserAgent, ctx.userAgent)
+                headers.forEach { (k, v) -> header(k, v) }
 
-        // If the response body is blank, it is replaced with an empty JSON string in order to avoid deserialization failures.
-        return ctx.json.decodeFromString<T>(body.ifBlank { "\"\"" })
+                block()
+            }
+
+        if (response.status.value !in 200..299) {
+            throw ctx.exceptionFactory(response)
+        }
+
+        val body = response.bodyAsText()
+
+        val safeBody = body.ifBlank { "\"\"" }
+
+        return ctx.json.decodeFromString<T>(safeBody)
     }
 }
-
-/**
- * Ensures that the HTTP response has a successful status code (2xx).
- *
- * @param factory A factory used to create an exception from the failed response.
- *
- * @return The original [HttpResponse] if the status code is successful.
- *
- * @throws Throwable created by [factory] if the response is not successful.
- */
-private fun HttpResponse<String>.ensureSuccess(factory: HttpExceptionFactory): HttpResponse<String> =
-    if (statusCode() in 200..299) {
-        this
-    } else {
-        throw factory(this)
-    }

--- a/src/main/kotlin/me/modmuss50/mpp/networking/HttpEngine.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/networking/HttpEngine.kt
@@ -6,11 +6,21 @@ import io.ktor.client.request.request
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
+import kotlinx.coroutines.runBlocking
 
 class HttpEngine(
-    private val ctx: HttpContext,
+    val ctx: HttpContext,
 ) {
-    internal suspend inline fun <reified T> request(
+    inline fun <reified T> request(
+        url: String,
+        headers: Map<String, String> = emptyMap(),
+        noinline block: HttpRequestBuilder.() -> Unit = {},
+    ): T =
+        runBlocking {
+            asyncRequest<T>(url, headers, block)
+        }
+
+    suspend inline fun <reified T> asyncRequest(
         url: String,
         headers: Map<String, String> = emptyMap(),
         block: HttpRequestBuilder.() -> Unit = {},

--- a/src/main/kotlin/me/modmuss50/mpp/networking/HttpException.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/networking/HttpException.kt
@@ -1,33 +1,16 @@
 package me.modmuss50.mpp.networking
 
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.Url
 import java.io.IOException
-import java.net.URI
-import java.net.http.HttpResponse
 
-/**
- * Exception representing a non-successful HTTP response.
- *
- * @property statusCode The HTTP status code returned by the server.
- * @property uri The URI that was requested.
- * @property body The response body as a string.
- * @property headers The response headers.
- * @property response The original [HttpResponse], if available.
- * @param message A human-readable error message describing the failure.
- */
 class HttpException(
     val statusCode: Int,
-    val uri: URI,
+    val url: Url,
     val body: String,
     val headers: Map<String, List<String>>,
-    val response: HttpResponse<String>?,
     message: String,
 ) : IOException(message)
 
-/**
- * A factory function used to convert an [HttpResponse] into an [HttpException].
- *
- * This allows callers to customize how HTTP errors are represented, including
- * shaping error messages or extracting additional metadata from the response.
- */
 typealias HttpExceptionFactory =
-(HttpResponse<String>) -> HttpException
+    suspend (HttpResponse) -> HttpException

--- a/src/main/kotlin/me/modmuss50/mpp/networking/MultipartBodyBuilder.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/networking/MultipartBodyBuilder.kt
@@ -1,10 +1,10 @@
 package me.modmuss50.mpp.networking
 
+import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.forms.formData
 import io.ktor.http.ContentType
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
-import io.ktor.http.content.PartData
 import java.io.File
 import java.nio.file.Path
 
@@ -15,7 +15,7 @@ class MultipartBodyBuilder {
         name: String,
         value: String,
     ): MultipartBodyBuilder {
-        parts.add(Part.Text(name, value))
+        parts += Part.Text(name, value)
         return this
     }
 
@@ -25,7 +25,7 @@ class MultipartBodyBuilder {
         file: File,
         mediaType: String? = null,
     ): MultipartBodyBuilder {
-        parts.add(Part.File(name, filename, file.toPath(), mediaType))
+        parts += Part.File(name, filename, file.toPath(), mediaType)
         return this
     }
 
@@ -35,39 +35,43 @@ class MultipartBodyBuilder {
         path: Path,
         mediaType: String? = null,
     ): MultipartBodyBuilder {
-        parts.add(Part.File(name, filename, path, mediaType))
+        parts += Part.File(name, filename, path, mediaType)
         return this
     }
 
-    fun build(): List<PartData> =
-        parts.map { part ->
-            when (part) {
-                is Part.Text -> {
-                    formData {
-                        append(part.name, part.value)
-                    }.first()
-                }
+    fun build(): MultiPartFormDataContent =
+        MultiPartFormDataContent(
+            formData {
+                for (part in parts) {
+                    when (part) {
+                        is Part.Text -> {
+                            append(part.name, part.value)
+                        }
 
-                is Part.File -> {
-                    formData {
-                        append(
-                            key = part.name,
-                            value = part.path.toFile().readBytes(),
-                            headers =
-                                Headers.build {
-                                    append(HttpHeaders.ContentDisposition, "filename=\"${part.filename}\"")
-                                    append(
-                                        HttpHeaders.ContentType,
-                                        part.mediaType ?: ContentType.Application.OctetStream.toString(),
-                                    )
-                                },
-                        )
-                    }.first()
+                        is Part.File -> {
+                            append(
+                                key = part.name,
+                                value = part.path.toFile().readBytes(),
+                                headers =
+                                    Headers.build {
+                                        append(
+                                            HttpHeaders.ContentDisposition,
+                                            "filename=\"${part.filename}\"",
+                                        )
+                                        append(
+                                            HttpHeaders.ContentType,
+                                            part.mediaType
+                                                ?: ContentType.Application.OctetStream.toString(),
+                                        )
+                                    },
+                            )
+                        }
+                    }
                 }
-            }
-        }
+            },
+        )
 
-    sealed class Part {
+    private sealed class Part {
         data class Text(
             val name: String,
             val value: String,

--- a/src/main/kotlin/me/modmuss50/mpp/networking/MultipartBodyBuilder.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/networking/MultipartBodyBuilder.kt
@@ -1,215 +1,83 @@
 package me.modmuss50.mpp.networking
 
+import io.ktor.client.request.forms.formData
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.content.PartData
 import java.io.File
-import java.net.http.HttpRequest
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
 import java.nio.file.Path
-import java.util.UUID
 
-/**
- * Utility for constructing `multipart/form-data` request bodies compatible with
- * Java's [HttpRequest] API.
- *
- * This builder accumulates form parts (text and files) and produces a single
- * [HttpRequest.BodyPublisher] when [build] is called.
- *
- * A unique boundary is generated per instance and **must** be included in the
- * `Content-Type` header via [getContentType].
- */
 class MultipartBodyBuilder {
-    /**
-     * Unique boundary string separating parts in the multipart payload.
-     *
-     * This value is randomly generated and stripped of dashes to ensure it is
-     * safe for use in HTTP headers and body formatting.
-     */
-    private val boundary = UUID.randomUUID().toString().replace("-", "")
-
-    /**
-     * Internal list of parts that will be serialized into the final request body.
-     */
     private val parts = mutableListOf<Part>()
 
-    /**
-     * Adds a simple text form field.
-     *
-     * @param name the form field name (used in the `Content-Disposition` header).
-     * @param value the string value of the field, encoded as UTF-8.
-     *
-     * @return this builder instance for chaining.
-     */
     fun addFormDataPart(
         name: String,
         value: String,
     ): MultipartBodyBuilder {
-        parts.add(TextPart(name, value))
+        parts.add(Part.Text(name, value))
         return this
     }
 
-    /**
-     * Adds a file form field using a [File].
-     *
-     * @param name the form field name (used in the `Content-Disposition` header).
-     * @param filename the filename reported in the multipart payload (does not have to match the actual file name).
-     * @param file the file to upload.
-     * @param mediaType optional MIME type; if null, it is resolved using [Files.probeContentType], or falls back to `application/octet-stream` if detection fails.
-     *
-     * @return this builder instance for chaining.
-     */
     fun addFormDataPart(
         name: String,
         filename: String,
         file: File,
         mediaType: String? = null,
     ): MultipartBodyBuilder {
-        parts.add(FilePart(name, filename, file.toPath(), mediaType))
+        parts.add(Part.File(name, filename, file.toPath(), mediaType))
         return this
     }
 
-    /**
-     * Adds a file form field using a [Path].
-     *
-     * @param name the form field name (used in the `Content-Disposition` header).
-     * @param filename the filename reported in the multipart payload (does not have to match the actual file name).
-     * @param path the file path to upload.
-     * @param mediaType optional MIME type; if null, it is resolved using [Files.probeContentType], or falls back to `application/octet-stream` if detection fails.
-     *
-     * @return this builder instance for chaining.
-     */
     fun addFormDataPart(
         name: String,
         filename: String,
         path: Path,
         mediaType: String? = null,
     ): MultipartBodyBuilder {
-        parts.add(FilePart(name, filename, path, mediaType))
+        parts.add(Part.File(name, filename, path, mediaType))
         return this
     }
 
-    /**
-     * Builds the multipart body as a single [HttpRequest.BodyPublisher].
-     *
-     * Each part is serialized with:
-     * - a leading boundary (`--boundary`)
-     * - appropriate headers
-     * - its content
-     * - a trailing CRLF
-     * - a closing boundary (`--boundary--`)
-     *
-     * @return a [HttpRequest.BodyPublisher] containing the complete multipart payload.
-     */
-    fun build(): HttpRequest.BodyPublisher {
-        val byteArrays = mutableListOf<ByteArray>()
+    fun build(): List<PartData> =
+        parts.map { part ->
+            when (part) {
+                is Part.Text -> {
+                    formData {
+                        append(part.name, part.value)
+                    }.first()
+                }
 
-        for (part in parts) {
-            byteArrays.add("--$boundary\r\n".toByteArray(StandardCharsets.UTF_8))
-            byteArrays.addAll(part.getBytes())
+                is Part.File -> {
+                    formData {
+                        append(
+                            key = part.name,
+                            value = part.path.toFile().readBytes(),
+                            headers =
+                                Headers.build {
+                                    append(HttpHeaders.ContentDisposition, "filename=\"${part.filename}\"")
+                                    append(
+                                        HttpHeaders.ContentType,
+                                        part.mediaType ?: ContentType.Application.OctetStream.toString(),
+                                    )
+                                },
+                        )
+                    }.first()
+                }
+            }
         }
 
-        byteArrays.add("--$boundary--\r\n".toByteArray(StandardCharsets.UTF_8))
+    sealed class Part {
+        data class Text(
+            val name: String,
+            val value: String,
+        ) : Part()
 
-        val totalBytes = byteArrays.sumOf { it.size }
-        val result = ByteArray(totalBytes)
-        var offset = 0
-
-        for (bytes in byteArrays) {
-            System.arraycopy(bytes, 0, result, offset, bytes.size)
-            offset += bytes.size
-        }
-
-        return HttpRequest.BodyPublishers.ofByteArray(result)
-    }
-
-    /**
-     * Returns the `Content-Type` header value for this multipart request.
-     *
-     * This value must be set on the HTTP request so the server can correctly
-     * parse the multipart body using the same boundary.
-     *
-     * @return a `multipart/form-data` content type string including the boundary parameter.
-     */
-    fun getContentType(): String = "multipart/form-data; boundary=$boundary"
-
-    /**
-     * Represents a single multipart section.
-     */
-    private sealed class Part {
-        /**
-         * Serializes this part into a list of byte arrays representing:
-         * - headers
-         * - content
-         * - trailing CRLF
-         *
-         * These byte arrays are later concatenated into the final payload.
-         *
-         * @return a list of byte arrays representing this part.
-         */
-        abstract fun getBytes(): List<ByteArray>
-    }
-
-    /**
-     * A simple text-based form field.
-     *
-     * @property name the form field name.
-     * @property value the UTF-8 encoded value of the field.
-     */
-    private class TextPart(
-        val name: String,
-        val value: String,
-    ) : Part() {
-        /**
-         * Encodes the text part including its `Content-Disposition` header and value.
-         *
-         * @return a list of byte arrays containing headers, value, and trailing CRLF.
-         */
-        override fun getBytes(): List<ByteArray> {
-            val result = mutableListOf<ByteArray>()
-            result.add("Content-Disposition: form-data; name=\"$name\"\r\n\r\n".toByteArray(StandardCharsets.UTF_8))
-            result.add(value.toByteArray(StandardCharsets.UTF_8))
-            result.add("\r\n".toByteArray(StandardCharsets.UTF_8))
-            return result
-        }
-    }
-
-    /**
-     * A file-based form field.
-     *
-     * @property name the form field name.
-     * @property filename the filename reported in the multipart payload.
-     * @property path the path to the file being uploaded.
-     * @property mediaType optional MIME type override.
-     */
-    private class FilePart(
-        val name: String,
-        val filename: String,
-        val path: Path,
-        val mediaType: String?,
-    ) : Part() {
-        /**
-         * Encodes the file part including headers and raw file contents.
-         *
-         * The content type is resolved in the following order:
-         * 1. Explicit [mediaType] if provided
-         * 2. Auto-detected via [Files.probeContentType]
-         * 3. Fallback to `application/octet-stream`
-         *
-         * @return a list of byte arrays containing headers, file bytes, and trailing CRLF.
-         */
-        override fun getBytes(): List<ByteArray> {
-            val result = mutableListOf<ByteArray>()
-            val contentType = mediaType ?: Files.probeContentType(path) ?: "application/octet-stream"
-
-            result.add(
-                "Content-Disposition: form-data; name=\"$name\"; filename=\"$filename\"\r\n".toByteArray(
-                    StandardCharsets.UTF_8,
-                ),
-            )
-            result.add("Content-Type: $contentType\r\n\r\n".toByteArray(StandardCharsets.UTF_8))
-            result.add(Files.readAllBytes(path))
-            result.add("\r\n".toByteArray(StandardCharsets.UTF_8))
-
-            return result
-        }
+        data class File(
+            val name: String,
+            val filename: String,
+            val path: Path,
+            val mediaType: String?,
+        ) : Part()
     }
 }

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeApi.kt
@@ -3,7 +3,6 @@ package me.modmuss50.mpp.platforms.curseforge
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import me.modmuss50.mpp.PlatformDependency
 import me.modmuss50.mpp.networking.DefaultHttpImpl
@@ -189,20 +188,16 @@ class CurseforgeApi(
     ): UploadFileResponse {
         val metadataJson = httpUtils.json.encodeToString(uploadMetadata)
 
-        val bodyBuilder =
+        val body =
             MultipartBodyBuilder()
                 .addFormDataPart("file", path.name, path, "application/java-archive")
                 .addFormDataPart("metadata", metadataJson)
-
-        val multipartHeaders =
-            headers.toMutableMap().apply {
-                this["Content-Type"] = bodyBuilder.getContentType()
-            }
+                .build()
 
         return httpUtils.post(
             url = "$baseUrl/api/projects/$projectId/upload-file",
-            body = bodyBuilder.build(),
-            headers = multipartHeaders,
+            body = body,
+            headers = headers,
         )
     }
 }

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/base/GiteaCompatibleApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitea/base/GiteaCompatibleApi.kt
@@ -2,7 +2,6 @@ package me.modmuss50.mpp.platforms.gitea.base
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import me.modmuss50.mpp.networking.DefaultHttpImpl
 import me.modmuss50.mpp.networking.HttpConfig
@@ -87,14 +86,21 @@ class GiteaCompatibleApi(
         release: Release,
         file: File,
     ) {
-        val bodyBuilder =
+        val body =
             MultipartBodyBuilder()
-                .addFormDataPart("attachment", file.name, file, "application/java-archive")
+                .addFormDataPart(
+                    "attachment",
+                    file.name,
+                    file,
+                    "application/java-archive",
+                )
+                .build()
 
-        val multipartHeaders = headers.toMutableMap()
-        multipartHeaders["Content-Type"] = bodyBuilder.getContentType()
-
-        return httpUtils.post(release.uploadUrl, bodyBuilder.build(), multipartHeaders)
+        return httpUtils.post(
+            url = release.uploadUrl,
+            body = body,
+            headers = headers,
+        )
     }
 
     // https://docs.gitea.com/api/1.24/#tag/repository/operation/repoEditRelease

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/GitlabApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/gitlab/GitlabApi.kt
@@ -3,7 +3,6 @@ package me.modmuss50.mpp.platforms.gitlab
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import me.modmuss50.mpp.networking.DefaultHttpImpl
 import me.modmuss50.mpp.networking.HttpConfig
@@ -120,10 +119,14 @@ class GitlabApi(
         file: File,
     ): AssetLink {
         val url = "$apiEndpoint/projects/$projectId/uploads"
-        val builder = MultipartBodyBuilder().addFormDataPart("file", file.name, file)
-        val bodyPublisher = builder.build()
-        val headersWithContentType = headers + ("Content-Type" to builder.getContentType())
-        val response: UploadResponse = httpUtils.post(url, bodyPublisher, headersWithContentType)
+        val body = MultipartBodyBuilder().addFormDataPart("file", file.name, file).build()
+
+        val response: UploadResponse =
+            httpUtils.post(
+                url = url,
+                body = body,
+                headers = headers,
+            )
 
         return AssetLink(
             name = file.name,

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/modrinth/ModrinthApi.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/modrinth/ModrinthApi.kt
@@ -2,7 +2,6 @@ package me.modmuss50.mpp.platforms.modrinth
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import me.modmuss50.mpp.PlatformDependency
 import me.modmuss50.mpp.ReleaseType
@@ -13,7 +12,6 @@ import me.modmuss50.mpp.networking.MultipartBodyBuilder
 import java.net.http.HttpRequest
 import java.nio.file.Path
 import java.time.Duration
-import kotlin.io.path.name
 
 // https://docs.modrinth.com/api-spec/#tag/versions/operation/createVersion
 class ModrinthApi(
@@ -173,18 +171,26 @@ class ModrinthApi(
     ): CreateVersionResponse {
         val metadataJson = Json.encodeToString(metadata)
 
-        val bodyBuilder =
+        val body =
             MultipartBodyBuilder()
                 .addFormDataPart("data", metadataJson)
+                .apply {
+                    for ((name, path) in files) {
+                        addFormDataPart(
+                            name = name,
+                            filename = path.fileName.toString(),
+                            path = path,
+                            mediaType = "application/java-archive",
+                        )
+                    }
+                }
+                .build()
 
-        for ((name, path) in files) {
-            bodyBuilder.addFormDataPart(name, path.name, path, "application/java-archive")
-        }
-
-        val multipartHeaders = headers.toMutableMap()
-        multipartHeaders["Content-Type"] = bodyBuilder.getContentType()
-
-        return httpUtils.post("$baseUrl/version", bodyBuilder.build(), multipartHeaders)
+        return httpUtils.post(
+            url = "$baseUrl/version",
+            body = body,
+            headers = headers,
+        )
     }
 
     fun checkProject(projectSlug: String): ProjectCheckResponse = httpUtils.get("$baseUrl/project/$projectSlug/check", headers)


### PR DESCRIPTION
Switching over to Ktor would allow much more flexibility with networking in the future. This draft uses CIO which is a lightweight client, but there are many other options out there which would be easy to switch over to in the future. Ktor also provides testing packages which could replace the use of Javalin and create more consistency between the test server and the production server. I think a proper Ktor implementation based on this work is worth considering as mod-publish-plugin becomes a more stable project, but it is also worth noting that refactoring the tests will take a fair amount of time.

Some immediate benefits of Ktor I can think of would be the ability to stream data rather than in-memory buffering, explicit coroutine support, and better Kotlin integration.

Notes:
- I removed the comment blocks as most would need to be rewritten to reflect these changes anyway.
- The work here is untested and should not be viewed as a final implementation suggestion.
- The tests will all fail as I did not refactor them to work with Ktor.