### PR TITLE
Add Minecraft plugin support for Curseforge

### DIFF
--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
@@ -37,6 +37,21 @@ interface CurseforgeOptions :
     PlatformOptions,
     PlatformOptionsInternal<CurseforgeOptions>,
     CurseforgeDependencyContainer {
+    companion object {
+        @JvmStatic
+        val PLUGIN_LOADERS =
+            setOf(
+                "paper",
+                "spigot",
+                "bukkit",
+                "folia",
+                "purpur",
+                "bungeecord",
+                "velocity",
+                "waterfall",
+            )
+    }
+
     @get:Input
     val projectId: Property<String>
 
@@ -44,6 +59,9 @@ interface CurseforgeOptions :
     @get:Input
     @get:Optional
     val projectSlug: Property<String>
+
+    @get:Input
+    val plugin: Property<Boolean>
 
     @get:Input
     val minecraftVersions: ListProperty<String>
@@ -86,6 +104,7 @@ interface CurseforgeOptions :
         fromDependencies(other)
         projectId.convention(other.projectId)
         projectSlug.convention(other.projectSlug)
+        plugin.convention(other.plugin)
         minecraftVersions.convention(other.minecraftVersions)
         client.convention(other.client)
         server.convention(other.server)
@@ -165,6 +184,8 @@ interface CurseforgeOptions :
     override fun setInternalDefaults() {
         apiEndpoint.convention("https://minecraft.curseforge.com")
         changelogType.convention("markdown")
+        // Default plugin to true if loaders are ONLY plugin loaders
+        plugin.convention(modLoaders.map { loaders -> loaders.isNotEmpty() && loaders.all { it in PLUGIN_LOADERS } })
     }
 
     override val platformDependencyKClass: KClass<CurseforgeDependency>
@@ -252,8 +273,9 @@ constructor(
         Validators.validateUnique("minecraftVersions", minecraftVersions)
         Validators.validateUnique("javaVersions", javaVersions)
 
-        if (client.orNull != true && server.orNull != true) {
-            throw IllegalArgumentException("At least one of client or server must be set to true")
+        // Plugins don't have environments
+        if (!plugin.get() && client.orNull != true && server.orNull != true) {
+            throw IllegalArgumentException("At least one of client or server must be set to true when plugin is false")
         }
     }
 
@@ -298,23 +320,27 @@ constructor(
 
                 val gameVersions = ArrayList<Int>()
                 for (version in minecraftVersions.get()) {
-                    gameVersions.add(versions.getMinecraftVersion(version))
+                    gameVersions.add(versions.getMinecraftVersion(version, plugin.get()))
                 }
 
                 for (modLoader in modLoaders.get()) {
-                    gameVersions.add(versions.getModLoaderVersion(modLoader))
+                    // Failed mod-loaders are likely plugin-based ones (ex: "spigot")
+                    runCatching { versions.getModLoaderVersion(modLoader) }.onSuccess { gameVersions.add(it) }
                 }
 
-                if (client.isPresent && client.get()) {
-                    gameVersions.add(versions.getClientVersion())
-                }
+                // Mod-specific stuff (non-plugin)
+                if (!plugin.get()) {
+                    if (client.isPresent && client.get()) {
+                        gameVersions.add(versions.getClientVersion())
+                    }
 
-                if (server.isPresent && server.get()) {
-                    gameVersions.add(versions.getServerVersion())
-                }
+                    if (server.isPresent && server.get()) {
+                        gameVersions.add(versions.getServerVersion())
+                    }
 
-                for (javaVersion in javaVersions.get()) {
-                    gameVersions.add(versions.getJavaVersion(javaVersion))
+                    for (javaVersion in javaVersions.get()) {
+                        gameVersions.add(versions.getJavaVersion(javaVersion))
+                    }
                 }
 
                 val projectRelations =

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
@@ -185,7 +185,12 @@ interface CurseforgeOptions :
         apiEndpoint.convention("https://minecraft.curseforge.com")
         changelogType.convention("markdown")
         // Default plugin to true if loaders are ONLY plugin loaders
-        plugin.convention(modLoaders.map { loaders -> loaders.isNotEmpty() && loaders.all { it in PLUGIN_LOADERS } })
+        plugin.convention(
+            modLoaders.map { loaders ->
+                val normalized = loaders.map { it.lowercase() }
+                normalized.isNotEmpty() && normalized.all { it in PLUGIN_LOADERS }
+            },
+        )
     }
 
     override val platformDependencyKClass: KClass<CurseforgeDependency>

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/Curseforge.kt
@@ -38,6 +38,8 @@ interface CurseforgeOptions :
     PlatformOptionsInternal<CurseforgeOptions>,
     CurseforgeDependencyContainer {
     companion object {
+        // These are only used for automatic setting of plugin property.
+        // Property can still be set manually, in which case these aren't used at all.
         @JvmStatic
         val PLUGIN_LOADERS =
             setOf(
@@ -276,11 +278,14 @@ constructor(
     override fun validateInputs() {
         super.validateInputs()
         Validators.validateUnique("minecraftVersions", minecraftVersions)
-        Validators.validateUnique("javaVersions", javaVersions)
 
-        // Plugins don't have environments
-        if (!plugin.get() && client.orNull != true && server.orNull != true) {
-            throw IllegalArgumentException("At least one of client or server must be set to true when plugin is false")
+        // Plugins don't have javaVersions or environments
+        if (!plugin.get()) {
+            Validators.validateUnique("javaVersions", javaVersions)
+
+            if (client.orNull != true && server.orNull != true) {
+                throw IllegalArgumentException("At least one of client or server must be set to true when plugin is false")
+            }
         }
     }
 
@@ -323,18 +328,21 @@ constructor(
                         },
                     )
 
+                // Mods and plugins use different game versions
                 val gameVersions = ArrayList<Int>()
-                for (version in minecraftVersions.get()) {
-                    gameVersions.add(versions.getMinecraftVersion(version, plugin.get()))
-                }
+                if (plugin.get()) {
+                    for (version in minecraftVersions.get()) {
+                        gameVersions.add(versions.getMinecraftPluginVersion(version))
+                    }
+                } else {
+                    for (version in minecraftVersions.get()) {
+                        gameVersions.add(versions.getMinecraftVersion(version))
+                    }
 
-                for (modLoader in modLoaders.get()) {
-                    // Failed mod-loaders are likely plugin-based ones (ex: "spigot")
-                    runCatching { versions.getModLoaderVersion(modLoader) }.onSuccess { gameVersions.add(it) }
-                }
+                    for (modLoader in modLoaders.get()) {
+                        gameVersions.add(versions.getModLoaderVersion(modLoader))
+                    }
 
-                // Mod-specific stuff (non-plugin)
-                if (!plugin.get()) {
                     if (client.isPresent && client.get()) {
                         gameVersions.add(versions.getClientVersion())
                     }

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeVersions.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeVersions.kt
@@ -6,12 +6,24 @@ class CurseforgeVersions(
     private val versionTypes: List<CurseforgeApi.GameVersionType>,
     private val versions: List<CurseforgeApi.GameVersion>,
 ) {
+    companion object {
+        // Not documented anywhere, but Minecraft versions for plugins use game version type ID = 1.
+        // It's not even returned in CurseForge's version-types API...
+        @JvmStatic
+        val PLUGIN_MINECRAFT_VERSION_TYPE_ID = 1
+    }
 
     private fun getGameVersionTypes(name: String): List<Int> {
-        val versions = if (name == "minecraft") {
-            versionTypes.filter { it.slug.startsWith("minecraft") }
-        } else {
-            versionTypes.filter { it.slug == name }
+        val versions = when (name) {
+            "minecraft" -> {
+                versionTypes.filter { it.slug.startsWith("minecraft") }
+            }
+            "minecraftPlugin" -> {
+                return listOf(PLUGIN_MINECRAFT_VERSION_TYPE_ID)
+            }
+            else -> {
+                versionTypes.filter { it.slug == name }
+            }
         }.map { it.id }
 
         if (versions.isEmpty()) {
@@ -27,8 +39,8 @@ class CurseforgeVersions(
         return version.id
     }
 
-    fun getMinecraftVersion(name: String): Int {
-        return getVersion(name, "minecraft")
+    fun getMinecraftVersion(name: String, plugin: Boolean): Int {
+        return getVersion(name, if (plugin) "minecraftPlugin" else "minecraft")
     }
 
     fun getModLoaderVersion(name: String): Int {

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeVersions.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeVersions.kt
@@ -8,7 +8,7 @@ class CurseforgeVersions(
 ) {
     companion object {
         // Not documented anywhere, but Minecraft versions for plugins use game version type ID = 1.
-        // It's not even returned in CurseForge's version-types API...
+        // It's not returned in version-types either, so the only solution is to hard-code it.
         @JvmStatic
         val PLUGIN_MINECRAFT_VERSION_TYPE_ID = 1
     }
@@ -40,12 +40,10 @@ class CurseforgeVersions(
     }
 
     fun getMinecraftVersion(name: String): Int {
-        return getMinecraftVersion(name, plugin = false)
+        return getVersion(name, "minecraft")
     }
 
-    fun getMinecraftVersion(name: String, plugin: Boolean): Int {
-        if (!plugin) return getVersion(name, "minecraft")
-        // Plugin
+    fun getMinecraftPluginVersion(name: String): Int {
         return try {
             getVersion(name, "minecraftPlugin")
         } catch (_: IllegalStateException) {

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeVersions.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeVersions.kt
@@ -39,9 +39,12 @@ class CurseforgeVersions(
         return version.id
     }
 
+    fun getMinecraftVersion(name: String): Int {
+        return getMinecraftVersion(name, plugin = false)
+    }
+
     fun getMinecraftVersion(name: String, plugin: Boolean): Int {
         if (!plugin) return getVersion(name, "minecraft")
-
         // Plugin
         return try {
             getVersion(name, "minecraftPlugin")

--- a/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeVersions.kt
+++ b/src/main/kotlin/me/modmuss50/mpp/platforms/curseforge/CurseforgeVersions.kt
@@ -40,7 +40,17 @@ class CurseforgeVersions(
     }
 
     fun getMinecraftVersion(name: String, plugin: Boolean): Int {
-        return getVersion(name, if (plugin) "minecraftPlugin" else "minecraft")
+        if (!plugin) return getVersion(name, "minecraft")
+
+        // Plugin
+        return try {
+            getVersion(name, "minecraftPlugin")
+        } catch (_: IllegalStateException) {
+            // Try major.minor (no patch)
+            val parts = name.split(".")
+            if (parts.size < 2) throw IllegalStateException("Failed to find version: $name")
+            getVersion("${parts[0]}.${parts[1]}", "minecraftPlugin")
+        }
     }
 
     fun getModLoaderVersion(name: String): Int {

--- a/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeTest.kt
@@ -612,4 +612,104 @@ class CurseforgeTest : IntegrationTest {
         assertEquals("Fabric", metadata[1].displayName)
         assertEquals("Forge", metadata[2].displayName)
     }
+
+    @Test
+    fun uploadCurseforgePlugin() {
+        val server = MockWebServer(MockCurseforgeApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                publishMods {
+                    file = tasks.jar.flatMap { it.archiveFile }
+                    changelog = "Hello!"
+                    version = "1.0.0"
+                    type = BETA
+                    modLoaders.add("paper")
+
+                    curseforge {
+                        accessToken = "123"
+                        projectId = "123456"
+                        minecraftVersions.add("1.20.1")
+                        apiEndpoint = "${server.endpoint}"
+                    }
+                }
+                """.trimIndent(),
+            )
+            .run("publishCurseforge")
+        server.close()
+
+        val metadata = server.api.lastMetadata!!
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishCurseforge")!!.outcome)
+        assertContains(metadata.gameVersions!!, 9994) // 1.20.1 (plugin version type)
+        assertFalse(metadata.gameVersions!!.contains(9990)) // 1.20.1 (standard version type)
+        assertFalse(metadata.gameVersions!!.contains(9638)) // Client (skipped for plugins)
+        assertFalse(metadata.gameVersions!!.contains(9639)) // Server (skipped for plugins)
+    }
+
+    @Test
+    fun uploadCurseforgePluginWithVersionRange() {
+        val server = MockWebServer(MockCurseforgeApi())
+
+        val result = gradleTest()
+            .buildScript(
+                """
+                publishMods {
+                    file = tasks.jar.flatMap { it.archiveFile }
+                    changelog = "Hello!"
+                    version = "1.0.0"
+                    type = BETA
+                    modLoaders.add("spigot")
+
+                    curseforge {
+                        accessToken = "123"
+                        projectId = "123456"
+                        minecraftVersionRange {
+                            start = "1.19.4"
+                            end = "1.20.1"
+                        }
+                        apiEndpoint = "${server.endpoint}"
+                    }
+                }
+                """.trimIndent(),
+            )
+            .run("publishCurseforge")
+        server.close()
+
+        val metadata = server.api.lastMetadata!!
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishCurseforge")!!.outcome)
+        assertContains(metadata.gameVersions!!, 9973) // 1.19.4 (plugin version type)
+        assertContains(metadata.gameVersions!!, 9994) // 1.20.1 (plugin version type)
+        assertFalse(metadata.gameVersions!!.contains(9776)) // 1.19.4 (standard version type, should not be present)
+        assertFalse(metadata.gameVersions!!.contains(9990)) // 1.20.1 (standard version type, should not be present)
+    }
+
+    @Test
+    fun dryRunCurseforgePluginDoesNotRequireClientOrServer() {
+        val result = gradleTest()
+            .buildScript(
+                """
+                publishMods {
+                    file = tasks.jar.flatMap { it.archiveFile }
+                    changelog = "Hello!"
+                    version = "1.0.0"
+                    type = BETA
+                    modLoaders.add("spigot")
+
+                    dryRun = true
+
+                    curseforge {
+                        accessToken = providers.environmentVariable("TEST_TOKEN_THAT_DOES_NOT_EXISTS")
+                        projectId = "123456"
+                        minecraftVersions.add("1.20.1")
+                    }
+                }
+                """.trimIndent(),
+            )
+            .run("publishCurseforge")
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":publishCurseforge")!!.outcome)
+    }
 }

--- a/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeVersionsTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeVersionsTest.kt
@@ -13,7 +13,13 @@ class CurseforgeVersionsTest {
     @Test
     fun minecraftVersions() {
         val versions = createVersions()
-        assertEquals(9990, versions.getMinecraftVersion("1.20.1"))
+        assertEquals(9990, versions.getMinecraftVersion("1.20.1", false))
+    }
+
+    @Test
+    fun minecraftVersionsPlugin() {
+        val versions = createVersions()
+        assertEquals(9994, versions.getMinecraftVersion("1.20.1", true))
     }
 
     @Test

--- a/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeVersionsTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeVersionsTest.kt
@@ -13,31 +13,31 @@ class CurseforgeVersionsTest {
     @Test
     fun minecraftVersions() {
         val versions = createVersions()
-        assertEquals(9990, versions.getMinecraftVersion("1.20.1", false))
+        assertEquals(9990, versions.getMinecraftVersion("1.20.1"))
     }
 
     @Test
     fun minecraftVersionsPlugin1_8_3() {
         val versions = createVersions()
-        assertEquals(568, versions.getMinecraftVersion("1.8.3", true))
+        assertEquals(568, versions.getMinecraftPluginVersion("1.8.3"))
     }
 
     @Test
     fun minecraftVersionsPlugin1_8_8() {
         val versions = createVersions()
-        assertEquals(531, versions.getMinecraftVersion("1.8.8", true))
+        assertEquals(531, versions.getMinecraftPluginVersion("1.8.8"))
     }
 
     @Test
     fun minecraftVersionsPlugin1_12_2() {
         val versions = createVersions()
-        assertEquals(6588, versions.getMinecraftVersion("1.12.2", true))
+        assertEquals(6588, versions.getMinecraftPluginVersion("1.12.2"))
     }
 
     @Test
     fun minecraftVersionsPlugin1_20_1() {
         val versions = createVersions()
-        assertEquals(9994, versions.getMinecraftVersion("1.20.1", true))
+        assertEquals(9994, versions.getMinecraftPluginVersion("1.20.1"))
     }
 
     @Test

--- a/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeVersionsTest.kt
+++ b/src/test/kotlin/me/modmuss50/mpp/test/curseforge/CurseforgeVersionsTest.kt
@@ -17,7 +17,25 @@ class CurseforgeVersionsTest {
     }
 
     @Test
-    fun minecraftVersionsPlugin() {
+    fun minecraftVersionsPlugin1_8_3() {
+        val versions = createVersions()
+        assertEquals(568, versions.getMinecraftVersion("1.8.3", true))
+    }
+
+    @Test
+    fun minecraftVersionsPlugin1_8_8() {
+        val versions = createVersions()
+        assertEquals(531, versions.getMinecraftVersion("1.8.8", true))
+    }
+
+    @Test
+    fun minecraftVersionsPlugin1_12_2() {
+        val versions = createVersions()
+        assertEquals(6588, versions.getMinecraftVersion("1.12.2", true))
+    }
+
+    @Test
+    fun minecraftVersionsPlugin1_20_1() {
         val versions = createVersions()
         assertEquals(9994, versions.getMinecraftVersion("1.20.1", true))
     }


### PR DESCRIPTION
`getMinecraftVersion(String)` now accepts a boolean for whether to get the Minecraft version for a plugin rather than a mod. This will use the game version type ID of 1, which is not returned in `version-types` API and you just need to "know it" I guess.

To be able to know when that boolean should be true, a `plugin` property was added to `CurseforgeOptions` that is true by default when ALL mod-loaders are plugin-based (projects with mixed loaders are assumed to be mod-first, and can always manually change `plugin`).

Since plugins don't have environments or specific Java versions (corect me if I'm wrong), their game versions shouldn't be applied either (otherwise the API will error saying it doesn't recognize it).

All new tests pass.

Maybe I'll add documentation for it but I'm lowkey lazy...

Fixes #112